### PR TITLE
Feature: Undertow access log configuration by properties

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
@@ -16,11 +16,6 @@
 
 package org.springframework.boot.autoconfigure.web;
 
-import io.undertow.server.HandlerWrapper;
-import io.undertow.server.HttpHandler;
-import io.undertow.server.handlers.accesslog.AccessLogHandler;
-import io.undertow.server.handlers.accesslog.DefaultAccessLogReceiver;
-import io.undertow.servlet.api.DeploymentInfo;
 import org.apache.catalina.Context;
 import org.apache.catalina.connector.Connector;
 import org.apache.catalina.valves.AccessLogValve;
@@ -32,7 +27,6 @@ import org.springframework.boot.context.embedded.*;
 import org.springframework.boot.context.embedded.tomcat.TomcatConnectorCustomizer;
 import org.springframework.boot.context.embedded.tomcat.TomcatContextCustomizer;
 import org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainerFactory;
-import org.springframework.boot.context.embedded.undertow.UndertowDeploymentInfoCustomizer;
 import org.springframework.boot.context.embedded.undertow.UndertowEmbeddedServletContainerFactory;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
@@ -635,28 +629,11 @@ public class ServerProperties implements EmbeddedServletContainerCustomizer, Ord
             factory.setWorkerThreads(this.workerThreads);
             factory.setDirectBuffers(this.directBuffers);
 
-
             if (isAccessLogEnabled()) {
                 factory.setBaseDirectory(this.basedir);
-
-                factory.addDeploymentInfoCustomizers(new UndertowDeploymentInfoCustomizer() {
-                    @Override
-                    public void customize(final DeploymentInfo deploymentInfo) {
-                        deploymentInfo.addInitialHandlerChainWrapper(new HandlerWrapper() {
-                            @Override
-                            public HttpHandler wrap(HttpHandler handler) {
-                                String formatString = (accessLogPattern != null) ? accessLogPattern : "common";
-
-                                DefaultAccessLogReceiver accessLogReceiver = new DefaultAccessLogReceiver(deploymentInfo.getExecutor(), getBasedir(), "access_log");
-
-                                return new AccessLogHandler(handler, accessLogReceiver, formatString, deploymentInfo.getClassLoader());
-                            }
-                        });
-                    }
-                });
+                factory.setAccessLogPattern(this.accessLogPattern);
+                factory.setAccessLogEnabled(this.accessLogEnabled);
             }
-
-
         }
 
     }

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
@@ -16,14 +16,11 @@
 
 package org.springframework.boot.autoconfigure.web;
 
-import java.io.File;
-import java.net.InetAddress;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-
-import javax.validation.constraints.NotNull;
-
+import io.undertow.server.HandlerWrapper;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.handlers.accesslog.AccessLogHandler;
+import io.undertow.server.handlers.accesslog.DefaultAccessLogReceiver;
+import io.undertow.servlet.api.DeploymentInfo;
 import org.apache.catalina.Context;
 import org.apache.catalina.connector.Connector;
 import org.apache.catalina.valves.AccessLogValve;
@@ -31,21 +28,23 @@ import org.apache.catalina.valves.RemoteIpValve;
 import org.apache.coyote.AbstractProtocol;
 import org.apache.coyote.ProtocolHandler;
 import org.apache.coyote.http11.AbstractHttp11Protocol;
-import org.springframework.boot.context.embedded.ConfigurableEmbeddedServletContainer;
-import org.springframework.boot.context.embedded.EmbeddedServletContainerCustomizer;
-import org.springframework.boot.context.embedded.EmbeddedServletContainerCustomizerBeanPostProcessor;
-import org.springframework.boot.context.embedded.EmbeddedServletContainerFactory;
-import org.springframework.boot.context.embedded.InitParameterConfiguringServletContextInitializer;
-import org.springframework.boot.context.embedded.JspServlet;
-import org.springframework.boot.context.embedded.Ssl;
+import org.springframework.boot.context.embedded.*;
 import org.springframework.boot.context.embedded.tomcat.TomcatConnectorCustomizer;
 import org.springframework.boot.context.embedded.tomcat.TomcatContextCustomizer;
 import org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainerFactory;
+import org.springframework.boot.context.embedded.undertow.UndertowDeploymentInfoCustomizer;
 import org.springframework.boot.context.embedded.undertow.UndertowEmbeddedServletContainerFactory;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 import org.springframework.core.Ordered;
 import org.springframework.util.StringUtils;
+
+import javax.validation.constraints.NotNull;
+import java.io.File;
+import java.net.InetAddress;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * {@link ConfigurationProperties} for a web server (e.g. port and path settings). Will be
@@ -56,557 +55,610 @@ import org.springframework.util.StringUtils;
  * @author Stephane Nicoll
  * @author Andy Wilkinson
  * @author Ivan Sopov
+ * @author Marcos Barbero
  */
 @ConfigurationProperties(prefix = "server", ignoreUnknownFields = false)
 public class ServerProperties implements EmbeddedServletContainerCustomizer, Ordered {
 
-	/**
-	 * Server HTTP port.
-	 */
-	private Integer port;
-
-	/**
-	 * Network address to which the server should bind to.
-	 */
-	private InetAddress address;
-
-	/**
-	 * Session timeout in seconds.
-	 */
-	private Integer sessionTimeout;
-
-	/**
-	 * Context path of the application.
-	 */
-	private String contextPath;
-
-	@NestedConfigurationProperty
-	private Ssl ssl;
-
-	/**
-	 * Path of the main dispatcher servlet.
-	 */
-	@NotNull
-	private String servletPath = "/";
-
-	private final Tomcat tomcat = new Tomcat();
-
-	private final Undertow undertow = new Undertow();
-
-	@NestedConfigurationProperty
-	private JspServlet jspServlet;
-
-	/**
-	 * ServletContext parameters.
-	 */
-	private final Map<String, String> contextParameters = new HashMap<String, String>();
-
-	@Override
-	public int getOrder() {
-		return 0;
-	}
-
-	public Tomcat getTomcat() {
-		return this.tomcat;
-	}
-
-	public Undertow getUndertow() {
-		return this.undertow;
-	}
-
-	public String getContextPath() {
-		return this.contextPath;
-	}
-
-	public void setContextPath(String contextPath) {
-		this.contextPath = contextPath;
-	}
-
-	public String getServletPath() {
-		return this.servletPath;
-	}
-
-	public String getServletMapping() {
-		if (this.servletPath.equals("") || this.servletPath.equals("/")) {
-			return "/";
-		}
-		if (this.servletPath.contains("*")) {
-			return this.servletPath;
-		}
-		if (this.servletPath.endsWith("/")) {
-			return this.servletPath + "*";
-		}
-		return this.servletPath + "/*";
-	}
-
-	public String getServletPrefix() {
-		String result = this.servletPath;
-		if (result.contains("*")) {
-			result = result.substring(0, result.indexOf("*"));
-		}
-		if (result.endsWith("/")) {
-			result = result.substring(0, result.length() - 1);
-		}
-		return result;
-	}
-
-	public void setServletPath(String servletPath) {
-		this.servletPath = servletPath;
-	}
-
-	public Integer getPort() {
-		return this.port;
-	}
-
-	public void setPort(Integer port) {
-		this.port = port;
-	}
-
-	public InetAddress getAddress() {
-		return this.address;
-	}
-
-	public void setAddress(InetAddress address) {
-		this.address = address;
-	}
-
-	public Integer getSessionTimeout() {
-		return this.sessionTimeout;
-	}
-
-	public void setSessionTimeout(Integer sessionTimeout) {
-		this.sessionTimeout = sessionTimeout;
-	}
-
-	public Ssl getSsl() {
-		return this.ssl;
-	}
-
-	public void setSsl(Ssl ssl) {
-		this.ssl = ssl;
-	}
-
-	public JspServlet getJspServlet() {
-		return this.jspServlet;
-	}
-
-	public void setJspServlet(JspServlet jspServlet) {
-		this.jspServlet = jspServlet;
-	}
-
-	public Map<String, String> getContextParameters() {
-		return this.contextParameters;
-	}
-
-	public void setLoader(String value) {
-		// no op to support Tomcat running as a traditional container (not embedded)
-	}
-
-	@Override
-	public void customize(ConfigurableEmbeddedServletContainer container) {
-		if (getPort() != null) {
-			container.setPort(getPort());
-		}
-		if (getAddress() != null) {
-			container.setAddress(getAddress());
-		}
-		if (getContextPath() != null) {
-			container.setContextPath(getContextPath());
-		}
-		if (getSessionTimeout() != null) {
-			container.setSessionTimeout(getSessionTimeout());
-		}
-		if (getSsl() != null) {
-			container.setSsl(getSsl());
-		}
-		if (getJspServlet() != null) {
-			container.setJspServlet(getJspServlet());
-		}
-		if (container instanceof TomcatEmbeddedServletContainerFactory) {
-			getTomcat()
-					.customizeTomcat((TomcatEmbeddedServletContainerFactory) container);
-		}
-		if (container instanceof UndertowEmbeddedServletContainerFactory) {
-			getUndertow().customizeUndertow(
-					(UndertowEmbeddedServletContainerFactory) container);
-		}
-		container.addInitializers(new InitParameterConfiguringServletContextInitializer(
-				getContextParameters()));
-	}
-
-	public String[] getPathsArray(Collection<String> paths) {
-		String[] result = new String[paths.size()];
-		int i = 0;
-		for (String path : paths) {
-			result[i++] = getPath(path);
-		}
-		return result;
-	}
-
-	public String[] getPathsArray(String[] paths) {
-		String[] result = new String[paths.length];
-		int i = 0;
-		for (String path : paths) {
-			result[i++] = getPath(path);
-		}
-		return result;
-	}
-
-	public String getPath(String path) {
-		String prefix = getServletPrefix();
-		if (!path.startsWith("/")) {
-			path = "/" + path;
-		}
-		return prefix + path;
-	}
-
-	public static class Tomcat {
-
-		/**
-		 * Format pattern for access logs.
-		 */
-		private String accessLogPattern;
-
-		/**
-		 * Enable access log.
-		 */
-		private boolean accessLogEnabled = false;
-
-		/**
-		 * Regular expression that matches proxies that are to be trusted.
-		 */
-		private String internalProxies = "10\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}|" // 10/8
-				+ "192\\.168\\.\\d{1,3}\\.\\d{1,3}|" // 192.168/16
-				+ "169\\.254\\.\\d{1,3}\\.\\d{1,3}|" // 169.254/16
-				+ "127\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"; // 127/8
-
-		/**
-		 * Header that holds the incoming protocol, usually named "X-Forwarded-Proto".
-		 * Configured as a RemoteIpValve only if remoteIpHeader is also set.
-		 */
-		private String protocolHeader;
-
-		/**
-		 * Name of the HTTP header used to override the original port value.
-		 */
-		private String portHeader;
-
-		/**
-		 * Name of the http header from which the remote ip is extracted. Configured as a
-		 * RemoteIpValve only if remoteIpHeader is also set.
-		 */
-		private String remoteIpHeader;
-
-		/**
-		 * Tomcat base directory. If not specified a temporary directory will be used.
-		 */
-		private File basedir;
-
-		/**
-		 * Delay in seconds between the invocation of backgroundProcess methods.
-		 */
-		private int backgroundProcessorDelay = 30; // seconds
-
-		/**
-		 * Maximum amount of worker threads.
-		 */
-		private int maxThreads = 0; // Number of threads in protocol handler
-
-		/**
-		 * Maximum size in bytes of the HTTP message header.
-		 */
-		private int maxHttpHeaderSize = 0; // bytes
-
-		/**
-		 * Character encoding to use to decode the URI.
-		 */
-		private String uriEncoding;
-
-		/**
-		 * Controls response compression. Acceptable values are "off" to disable
-		 * compression, "on" to enable compression of responses over 2048 bytes, "force"
-		 * to force response compression, or an integer value to enable compression of
-		 * responses with content length that is at least that value.
-		 */
-		private String compression = "off";
-
-		/**
-		 * Comma-separated list of MIME types for which compression is used.
-		 */
-		private String compressableMimeTypes = "text/html,text/xml,text/plain";
-
-		public int getMaxThreads() {
-			return this.maxThreads;
-		}
-
-		public void setMaxThreads(int maxThreads) {
-			this.maxThreads = maxThreads;
-		}
-
-		public int getMaxHttpHeaderSize() {
-			return this.maxHttpHeaderSize;
-		}
-
-		public void setMaxHttpHeaderSize(int maxHttpHeaderSize) {
-			this.maxHttpHeaderSize = maxHttpHeaderSize;
-		}
-
-		public boolean getAccessLogEnabled() {
-			return this.accessLogEnabled;
-		}
-
-		public void setAccessLogEnabled(boolean accessLogEnabled) {
-			this.accessLogEnabled = accessLogEnabled;
-		}
-
-		public int getBackgroundProcessorDelay() {
-			return this.backgroundProcessorDelay;
-		}
-
-		public void setBackgroundProcessorDelay(int backgroundProcessorDelay) {
-			this.backgroundProcessorDelay = backgroundProcessorDelay;
-		}
-
-		public File getBasedir() {
-			return this.basedir;
-		}
-
-		public void setBasedir(File basedir) {
-			this.basedir = basedir;
-		}
-
-		public String getAccessLogPattern() {
-			return this.accessLogPattern;
-		}
-
-		public void setAccessLogPattern(String accessLogPattern) {
-			this.accessLogPattern = accessLogPattern;
-		}
-
-		public String getCompressableMimeTypes() {
-			return this.compressableMimeTypes;
-		}
-
-		public void setCompressableMimeTypes(String compressableMimeTypes) {
-			this.compressableMimeTypes = compressableMimeTypes;
-		}
-
-		public String getCompression() {
-			return this.compression;
-		}
-
-		public void setCompression(String compression) {
-			this.compression = compression;
-		}
-
-		public String getInternalProxies() {
-			return this.internalProxies;
-		}
-
-		public void setInternalProxies(String internalProxies) {
-			this.internalProxies = internalProxies;
-		}
-
-		public String getProtocolHeader() {
-			return this.protocolHeader;
-		}
-
-		public void setProtocolHeader(String protocolHeader) {
-			this.protocolHeader = protocolHeader;
-		}
-
-		public String getPortHeader() {
-			return this.portHeader;
-		}
-
-		public void setPortHeader(String portHeader) {
-			this.portHeader = portHeader;
-		}
-
-		public String getRemoteIpHeader() {
-			return this.remoteIpHeader;
-		}
-
-		public void setRemoteIpHeader(String remoteIpHeader) {
-			this.remoteIpHeader = remoteIpHeader;
-		}
-
-		public String getUriEncoding() {
-			return this.uriEncoding;
-		}
-
-		public void setUriEncoding(String uriEncoding) {
-			this.uriEncoding = uriEncoding;
-		}
-
-		void customizeTomcat(TomcatEmbeddedServletContainerFactory factory) {
-			if (getBasedir() != null) {
-				factory.setBaseDirectory(getBasedir());
-			}
-
-			factory.addContextCustomizers(new TomcatContextCustomizer() {
-				@Override
-				public void customize(Context context) {
-					context.setBackgroundProcessorDelay(Tomcat.this.backgroundProcessorDelay);
-				}
-			});
-
-			String remoteIpHeader = getRemoteIpHeader();
-			String protocolHeader = getProtocolHeader();
-			if (StringUtils.hasText(remoteIpHeader)
-					|| StringUtils.hasText(protocolHeader)) {
-				RemoteIpValve valve = new RemoteIpValve();
-				valve.setRemoteIpHeader(remoteIpHeader);
-				valve.setProtocolHeader(protocolHeader);
-				valve.setInternalProxies(getInternalProxies());
-				valve.setPortHeader(getPortHeader());
-				factory.addContextValves(valve);
-			}
-
-			if (this.maxThreads > 0) {
-				factory.addConnectorCustomizers(new TomcatConnectorCustomizer() {
-					@Override
-					public void customize(Connector connector) {
-						ProtocolHandler handler = connector.getProtocolHandler();
-						if (handler instanceof AbstractProtocol) {
-							@SuppressWarnings("rawtypes")
-							AbstractProtocol protocol = (AbstractProtocol) handler;
-							protocol.setMaxThreads(Tomcat.this.maxThreads);
-						}
-					}
-				});
-			}
-
-			if (this.maxHttpHeaderSize > 0) {
-				factory.addConnectorCustomizers(new TomcatConnectorCustomizer() {
-					@Override
-					public void customize(Connector connector) {
-						ProtocolHandler handler = connector.getProtocolHandler();
-						if (handler instanceof AbstractHttp11Protocol) {
-							@SuppressWarnings("rawtypes")
-							AbstractHttp11Protocol protocol = (AbstractHttp11Protocol) handler;
-							protocol.setMaxHttpHeaderSize(Tomcat.this.maxHttpHeaderSize);
-						}
-					}
-				});
-			}
-
-			factory.addConnectorCustomizers(new TomcatConnectorCustomizer() {
-
-				@Override
-				public void customize(Connector connector) {
-					ProtocolHandler handler = connector.getProtocolHandler();
-					if (handler instanceof AbstractHttp11Protocol) {
-						@SuppressWarnings("rawtypes")
-						AbstractHttp11Protocol protocol = (AbstractHttp11Protocol) handler;
-						protocol.setCompression(coerceCompression(Tomcat.this.compression));
-						protocol.setCompressableMimeTypes(Tomcat.this.compressableMimeTypes);
-					}
-				}
-
-				private String coerceCompression(String compression) {
-					if ("true".equalsIgnoreCase(compression)) {
-						return "on";
-					}
-					if ("false".equalsIgnoreCase(compression)) {
-						return "off";
-					}
-					return compression;
-				}
-
-			});
-
-			if (this.accessLogEnabled) {
-				AccessLogValve valve = new AccessLogValve();
-				String accessLogPattern = getAccessLogPattern();
-				if (accessLogPattern != null) {
-					valve.setPattern(accessLogPattern);
-				}
-				else {
-					valve.setPattern("common");
-				}
-				valve.setSuffix(".log");
-				factory.addContextValves(valve);
-			}
-			if (getUriEncoding() != null) {
-				factory.setUriEncoding(getUriEncoding());
-			}
-		}
-
-	}
-
-	public static class Undertow {
-
-		/**
-		 * Size of each buffer in bytes.
-		 */
-		private Integer bufferSize;
-
-		/**
-		 * Number of buffer per region.
-		 */
-		private Integer buffersPerRegion;
-
-		/**
-		 * Number of I/O threads to create for the worker.
-		 */
-		private Integer ioThreads;
-
-		/**
-		 * Number of worker threads.
-		 */
-		private Integer workerThreads;
-
-		private Boolean directBuffers;
-
-		public Integer getBufferSize() {
-			return this.bufferSize;
-		}
-
-		public void setBufferSize(Integer bufferSize) {
-			this.bufferSize = bufferSize;
-		}
-
-		public Integer getBuffersPerRegion() {
-			return this.buffersPerRegion;
-		}
-
-		public void setBuffersPerRegion(Integer buffersPerRegion) {
-			this.buffersPerRegion = buffersPerRegion;
-		}
-
-		public Integer getIoThreads() {
-			return this.ioThreads;
-		}
-
-		public void setIoThreads(Integer ioThreads) {
-			this.ioThreads = ioThreads;
-		}
-
-		public Integer getWorkerThreads() {
-			return this.workerThreads;
-		}
-
-		public void setWorkerThreads(Integer workerThreads) {
-			this.workerThreads = workerThreads;
-		}
-
-		public Boolean getDirectBuffers() {
-			return this.directBuffers;
-		}
-
-		public void setDirectBuffers(Boolean directBuffers) {
-			this.directBuffers = directBuffers;
-		}
-
-		void customizeUndertow(UndertowEmbeddedServletContainerFactory factory) {
-			factory.setBufferSize(this.bufferSize);
-			factory.setBuffersPerRegion(this.buffersPerRegion);
-			factory.setIoThreads(this.ioThreads);
-			factory.setWorkerThreads(this.workerThreads);
-			factory.setDirectBuffers(this.directBuffers);
-		}
-
-	}
+    private final Tomcat tomcat = new Tomcat();
+    private final Undertow undertow = new Undertow();
+    /**
+     * ServletContext parameters.
+     */
+    private final Map<String, String> contextParameters = new HashMap<String, String>();
+    /**
+     * Server HTTP port.
+     */
+    private Integer port;
+    /**
+     * Network address to which the server should bind to.
+     */
+    private InetAddress address;
+    /**
+     * Session timeout in seconds.
+     */
+    private Integer sessionTimeout;
+    /**
+     * Context path of the application.
+     */
+    private String contextPath;
+    @NestedConfigurationProperty
+    private Ssl ssl;
+    /**
+     * Path of the main dispatcher servlet.
+     */
+    @NotNull
+    private String servletPath = "/";
+    @NestedConfigurationProperty
+    private JspServlet jspServlet;
+
+    @Override
+    public int getOrder() {
+        return 0;
+    }
+
+    public Tomcat getTomcat() {
+        return this.tomcat;
+    }
+
+    public Undertow getUndertow() {
+        return this.undertow;
+    }
+
+    public String getContextPath() {
+        return this.contextPath;
+    }
+
+    public void setContextPath(String contextPath) {
+        this.contextPath = contextPath;
+    }
+
+    public String getServletPath() {
+        return this.servletPath;
+    }
+
+    public void setServletPath(String servletPath) {
+        this.servletPath = servletPath;
+    }
+
+    public String getServletMapping() {
+        if (this.servletPath.equals("") || this.servletPath.equals("/")) {
+            return "/";
+        }
+        if (this.servletPath.contains("*")) {
+            return this.servletPath;
+        }
+        if (this.servletPath.endsWith("/")) {
+            return this.servletPath + "*";
+        }
+        return this.servletPath + "/*";
+    }
+
+    public String getServletPrefix() {
+        String result = this.servletPath;
+        if (result.contains("*")) {
+            result = result.substring(0, result.indexOf("*"));
+        }
+        if (result.endsWith("/")) {
+            result = result.substring(0, result.length() - 1);
+        }
+        return result;
+    }
+
+    public Integer getPort() {
+        return this.port;
+    }
+
+    public void setPort(Integer port) {
+        this.port = port;
+    }
+
+    public InetAddress getAddress() {
+        return this.address;
+    }
+
+    public void setAddress(InetAddress address) {
+        this.address = address;
+    }
+
+    public Integer getSessionTimeout() {
+        return this.sessionTimeout;
+    }
+
+    public void setSessionTimeout(Integer sessionTimeout) {
+        this.sessionTimeout = sessionTimeout;
+    }
+
+    public Ssl getSsl() {
+        return this.ssl;
+    }
+
+    public void setSsl(Ssl ssl) {
+        this.ssl = ssl;
+    }
+
+    public JspServlet getJspServlet() {
+        return this.jspServlet;
+    }
+
+    public void setJspServlet(JspServlet jspServlet) {
+        this.jspServlet = jspServlet;
+    }
+
+    public Map<String, String> getContextParameters() {
+        return this.contextParameters;
+    }
+
+    public void setLoader(String value) {
+        // no op to support Tomcat running as a traditional container (not embedded)
+    }
+
+    @Override
+    public void customize(ConfigurableEmbeddedServletContainer container) {
+        if (getPort() != null) {
+            container.setPort(getPort());
+        }
+        if (getAddress() != null) {
+            container.setAddress(getAddress());
+        }
+        if (getContextPath() != null) {
+            container.setContextPath(getContextPath());
+        }
+        if (getSessionTimeout() != null) {
+            container.setSessionTimeout(getSessionTimeout());
+        }
+        if (getSsl() != null) {
+            container.setSsl(getSsl());
+        }
+        if (getJspServlet() != null) {
+            container.setJspServlet(getJspServlet());
+        }
+        if (container instanceof TomcatEmbeddedServletContainerFactory) {
+            getTomcat()
+                    .customizeTomcat((TomcatEmbeddedServletContainerFactory) container);
+        }
+        if (container instanceof UndertowEmbeddedServletContainerFactory) {
+            getUndertow().customizeUndertow(
+                    (UndertowEmbeddedServletContainerFactory) container);
+        }
+        container.addInitializers(new InitParameterConfiguringServletContextInitializer(
+                getContextParameters()));
+    }
+
+    public String[] getPathsArray(Collection<String> paths) {
+        String[] result = new String[paths.size()];
+        int i = 0;
+        for (String path : paths) {
+            result[i++] = getPath(path);
+        }
+        return result;
+    }
+
+    public String[] getPathsArray(String[] paths) {
+        String[] result = new String[paths.length];
+        int i = 0;
+        for (String path : paths) {
+            result[i++] = getPath(path);
+        }
+        return result;
+    }
+
+    public String getPath(String path) {
+        String prefix = getServletPrefix();
+        if (!path.startsWith("/")) {
+            path = "/" + path;
+        }
+        return prefix + path;
+    }
+
+    public static class Tomcat {
+
+        /**
+         * Format pattern for access logs.
+         */
+        private String accessLogPattern;
+
+        /**
+         * Enable access log.
+         */
+        private boolean accessLogEnabled = false;
+
+        /**
+         * Regular expression that matches proxies that are to be trusted.
+         */
+        private String internalProxies = "10\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}|" // 10/8
+                + "192\\.168\\.\\d{1,3}\\.\\d{1,3}|" // 192.168/16
+                + "169\\.254\\.\\d{1,3}\\.\\d{1,3}|" // 169.254/16
+                + "127\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"; // 127/8
+
+        /**
+         * Header that holds the incoming protocol, usually named "X-Forwarded-Proto".
+         * Configured as a RemoteIpValve only if remoteIpHeader is also set.
+         */
+        private String protocolHeader;
+
+        /**
+         * Name of the HTTP header used to override the original port value.
+         */
+        private String portHeader;
+
+        /**
+         * Name of the http header from which the remote ip is extracted. Configured as a
+         * RemoteIpValve only if remoteIpHeader is also set.
+         */
+        private String remoteIpHeader;
+
+        /**
+         * Tomcat base directory. If not specified a temporary directory will be used.
+         */
+        private File basedir;
+
+        /**
+         * Delay in seconds between the invocation of backgroundProcess methods.
+         */
+        private int backgroundProcessorDelay = 30; // seconds
+
+        /**
+         * Maximum amount of worker threads.
+         */
+        private int maxThreads = 0; // Number of threads in protocol handler
+
+        /**
+         * Maximum size in bytes of the HTTP message header.
+         */
+        private int maxHttpHeaderSize = 0; // bytes
+
+        /**
+         * Character encoding to use to decode the URI.
+         */
+        private String uriEncoding;
+
+        /**
+         * Controls response compression. Acceptable values are "off" to disable
+         * compression, "on" to enable compression of responses over 2048 bytes, "force"
+         * to force response compression, or an integer value to enable compression of
+         * responses with content length that is at least that value.
+         */
+        private String compression = "off";
+
+        /**
+         * Comma-separated list of MIME types for which compression is used.
+         */
+        private String compressableMimeTypes = "text/html,text/xml,text/plain";
+
+        public int getMaxThreads() {
+            return this.maxThreads;
+        }
+
+        public void setMaxThreads(int maxThreads) {
+            this.maxThreads = maxThreads;
+        }
+
+        public int getMaxHttpHeaderSize() {
+            return this.maxHttpHeaderSize;
+        }
+
+        public void setMaxHttpHeaderSize(int maxHttpHeaderSize) {
+            this.maxHttpHeaderSize = maxHttpHeaderSize;
+        }
+
+        public boolean getAccessLogEnabled() {
+            return this.accessLogEnabled;
+        }
+
+        public void setAccessLogEnabled(boolean accessLogEnabled) {
+            this.accessLogEnabled = accessLogEnabled;
+        }
+
+        public int getBackgroundProcessorDelay() {
+            return this.backgroundProcessorDelay;
+        }
+
+        public void setBackgroundProcessorDelay(int backgroundProcessorDelay) {
+            this.backgroundProcessorDelay = backgroundProcessorDelay;
+        }
+
+        public File getBasedir() {
+            return this.basedir;
+        }
+
+        public void setBasedir(File basedir) {
+            this.basedir = basedir;
+        }
+
+        public String getAccessLogPattern() {
+            return this.accessLogPattern;
+        }
+
+        public void setAccessLogPattern(String accessLogPattern) {
+            this.accessLogPattern = accessLogPattern;
+        }
+
+        public String getCompressableMimeTypes() {
+            return this.compressableMimeTypes;
+        }
+
+        public void setCompressableMimeTypes(String compressableMimeTypes) {
+            this.compressableMimeTypes = compressableMimeTypes;
+        }
+
+        public String getCompression() {
+            return this.compression;
+        }
+
+        public void setCompression(String compression) {
+            this.compression = compression;
+        }
+
+        public String getInternalProxies() {
+            return this.internalProxies;
+        }
+
+        public void setInternalProxies(String internalProxies) {
+            this.internalProxies = internalProxies;
+        }
+
+        public String getProtocolHeader() {
+            return this.protocolHeader;
+        }
+
+        public void setProtocolHeader(String protocolHeader) {
+            this.protocolHeader = protocolHeader;
+        }
+
+        public String getPortHeader() {
+            return this.portHeader;
+        }
+
+        public void setPortHeader(String portHeader) {
+            this.portHeader = portHeader;
+        }
+
+        public String getRemoteIpHeader() {
+            return this.remoteIpHeader;
+        }
+
+        public void setRemoteIpHeader(String remoteIpHeader) {
+            this.remoteIpHeader = remoteIpHeader;
+        }
+
+        public String getUriEncoding() {
+            return this.uriEncoding;
+        }
+
+        public void setUriEncoding(String uriEncoding) {
+            this.uriEncoding = uriEncoding;
+        }
+
+        void customizeTomcat(TomcatEmbeddedServletContainerFactory factory) {
+            if (getBasedir() != null) {
+                factory.setBaseDirectory(getBasedir());
+            }
+
+            factory.addContextCustomizers(new TomcatContextCustomizer() {
+                @Override
+                public void customize(Context context) {
+                    context.setBackgroundProcessorDelay(Tomcat.this.backgroundProcessorDelay);
+                }
+            });
+
+            String remoteIpHeader = getRemoteIpHeader();
+            String protocolHeader = getProtocolHeader();
+            if (StringUtils.hasText(remoteIpHeader)
+                    || StringUtils.hasText(protocolHeader)) {
+                RemoteIpValve valve = new RemoteIpValve();
+                valve.setRemoteIpHeader(remoteIpHeader);
+                valve.setProtocolHeader(protocolHeader);
+                valve.setInternalProxies(getInternalProxies());
+                valve.setPortHeader(getPortHeader());
+                factory.addContextValves(valve);
+            }
+
+            if (this.maxThreads > 0) {
+                factory.addConnectorCustomizers(new TomcatConnectorCustomizer() {
+                    @Override
+                    public void customize(Connector connector) {
+                        ProtocolHandler handler = connector.getProtocolHandler();
+                        if (handler instanceof AbstractProtocol) {
+                            @SuppressWarnings("rawtypes")
+                            AbstractProtocol protocol = (AbstractProtocol) handler;
+                            protocol.setMaxThreads(Tomcat.this.maxThreads);
+                        }
+                    }
+                });
+            }
+
+            if (this.maxHttpHeaderSize > 0) {
+                factory.addConnectorCustomizers(new TomcatConnectorCustomizer() {
+                    @Override
+                    public void customize(Connector connector) {
+                        ProtocolHandler handler = connector.getProtocolHandler();
+                        if (handler instanceof AbstractHttp11Protocol) {
+                            @SuppressWarnings("rawtypes")
+                            AbstractHttp11Protocol protocol = (AbstractHttp11Protocol) handler;
+                            protocol.setMaxHttpHeaderSize(Tomcat.this.maxHttpHeaderSize);
+                        }
+                    }
+                });
+            }
+
+            factory.addConnectorCustomizers(new TomcatConnectorCustomizer() {
+
+                @Override
+                public void customize(Connector connector) {
+                    ProtocolHandler handler = connector.getProtocolHandler();
+                    if (handler instanceof AbstractHttp11Protocol) {
+                        @SuppressWarnings("rawtypes")
+                        AbstractHttp11Protocol protocol = (AbstractHttp11Protocol) handler;
+                        protocol.setCompression(coerceCompression(Tomcat.this.compression));
+                        protocol.setCompressableMimeTypes(Tomcat.this.compressableMimeTypes);
+                    }
+                }
+
+                private String coerceCompression(String compression) {
+                    if ("true".equalsIgnoreCase(compression)) {
+                        return "on";
+                    }
+                    if ("false".equalsIgnoreCase(compression)) {
+                        return "off";
+                    }
+                    return compression;
+                }
+
+            });
+
+            if (this.accessLogEnabled) {
+                AccessLogValve valve = new AccessLogValve();
+                String accessLogPattern = getAccessLogPattern();
+                if (accessLogPattern != null) {
+                    valve.setPattern(accessLogPattern);
+                } else {
+                    valve.setPattern("common");
+                }
+                valve.setSuffix(".log");
+                factory.addContextValves(valve);
+            }
+            if (getUriEncoding() != null) {
+                factory.setUriEncoding(getUriEncoding());
+            }
+        }
+
+    }
+
+    public static class Undertow {
+
+        /**
+         * Size of each buffer in bytes.
+         */
+        private Integer bufferSize;
+
+        /**
+         * Number of buffer per region.
+         */
+        private Integer buffersPerRegion;
+
+        /**
+         * Number of I/O threads to create for the worker.
+         */
+        private Integer ioThreads;
+
+        /**
+         * Number of worker threads.
+         */
+        private Integer workerThreads;
+
+        private Boolean directBuffers;
+
+        /**
+         * Format pattern for access logs.
+         */
+        private String accessLogPattern;
+
+        /**
+         * Enable access log.
+         */
+        private boolean accessLogEnabled = false;
+
+        /**
+         * Undertow base directory. If not specified a temporary directory will be used.
+         */
+        private File basedir;
+
+        public String getAccessLogPattern() {
+            return accessLogPattern;
+        }
+
+        public void setAccessLogPattern(String accessLogPattern) {
+            this.accessLogPattern = accessLogPattern;
+        }
+
+        public boolean isAccessLogEnabled() {
+            return accessLogEnabled;
+        }
+
+        public void setAccessLogEnabled(boolean accessLogEnabled) {
+            this.accessLogEnabled = accessLogEnabled;
+        }
+
+        public File getBasedir() {
+            return basedir;
+        }
+
+        public void setBasedir(File basedir) {
+            this.basedir = basedir;
+        }
+
+        public Integer getBufferSize() {
+            return this.bufferSize;
+        }
+
+        public void setBufferSize(Integer bufferSize) {
+            this.bufferSize = bufferSize;
+        }
+
+        public Integer getBuffersPerRegion() {
+            return this.buffersPerRegion;
+        }
+
+        public void setBuffersPerRegion(Integer buffersPerRegion) {
+            this.buffersPerRegion = buffersPerRegion;
+        }
+
+        public Integer getIoThreads() {
+            return this.ioThreads;
+        }
+
+        public void setIoThreads(Integer ioThreads) {
+            this.ioThreads = ioThreads;
+        }
+
+        public Integer getWorkerThreads() {
+            return this.workerThreads;
+        }
+
+        public void setWorkerThreads(Integer workerThreads) {
+            this.workerThreads = workerThreads;
+        }
+
+        public Boolean getDirectBuffers() {
+            return this.directBuffers;
+        }
+
+        public void setDirectBuffers(Boolean directBuffers) {
+            this.directBuffers = directBuffers;
+        }
+
+        void customizeUndertow(final UndertowEmbeddedServletContainerFactory factory) {
+            factory.setBufferSize(this.bufferSize);
+            factory.setBuffersPerRegion(this.buffersPerRegion);
+            factory.setIoThreads(this.ioThreads);
+            factory.setWorkerThreads(this.workerThreads);
+            factory.setDirectBuffers(this.directBuffers);
+
+
+            if (isAccessLogEnabled()) {
+                factory.setBaseDirectory(this.basedir);
+
+                factory.addDeploymentInfoCustomizers(new UndertowDeploymentInfoCustomizer() {
+                    @Override
+                    public void customize(final DeploymentInfo deploymentInfo) {
+                        deploymentInfo.addInitialHandlerChainWrapper(new HandlerWrapper() {
+                            @Override
+                            public HttpHandler wrap(HttpHandler handler) {
+                                String formatString = (accessLogPattern != null) ? accessLogPattern : "common";
+
+                                DefaultAccessLogReceiver accessLogReceiver = new DefaultAccessLogReceiver(deploymentInfo.getExecutor(), getBasedir(), "access_log");
+
+                                return new AccessLogHandler(handler, accessLogReceiver, formatString, deploymentInfo.getClassLoader());
+                            }
+                        });
+                    }
+                });
+            }
+
+
+        }
+
+    }
 
 }

--- a/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
@@ -54,588 +54,589 @@ import java.util.Map;
 @ConfigurationProperties(prefix = "server", ignoreUnknownFields = false)
 public class ServerProperties implements EmbeddedServletContainerCustomizer, Ordered {
 
-    private final Tomcat tomcat = new Tomcat();
-    private final Undertow undertow = new Undertow();
-    /**
-     * ServletContext parameters.
-     */
-    private final Map<String, String> contextParameters = new HashMap<String, String>();
-    /**
-     * Server HTTP port.
-     */
-    private Integer port;
-    /**
-     * Network address to which the server should bind to.
-     */
-    private InetAddress address;
-    /**
-     * Session timeout in seconds.
-     */
-    private Integer sessionTimeout;
-    /**
-     * Context path of the application.
-     */
-    private String contextPath;
-    @NestedConfigurationProperty
-    private Ssl ssl;
-    /**
-     * Path of the main dispatcher servlet.
-     */
-    @NotNull
-    private String servletPath = "/";
-    @NestedConfigurationProperty
-    private JspServlet jspServlet;
-
-    @Override
-    public int getOrder() {
-        return 0;
-    }
-
-    public Tomcat getTomcat() {
-        return this.tomcat;
-    }
-
-    public Undertow getUndertow() {
-        return this.undertow;
-    }
-
-    public String getContextPath() {
-        return this.contextPath;
-    }
-
-    public void setContextPath(String contextPath) {
-        this.contextPath = contextPath;
-    }
-
-    public String getServletPath() {
-        return this.servletPath;
-    }
-
-    public void setServletPath(String servletPath) {
-        this.servletPath = servletPath;
-    }
-
-    public String getServletMapping() {
-        if (this.servletPath.equals("") || this.servletPath.equals("/")) {
-            return "/";
-        }
-        if (this.servletPath.contains("*")) {
-            return this.servletPath;
-        }
-        if (this.servletPath.endsWith("/")) {
-            return this.servletPath + "*";
-        }
-        return this.servletPath + "/*";
-    }
-
-    public String getServletPrefix() {
-        String result = this.servletPath;
-        if (result.contains("*")) {
-            result = result.substring(0, result.indexOf("*"));
-        }
-        if (result.endsWith("/")) {
-            result = result.substring(0, result.length() - 1);
-        }
-        return result;
-    }
-
-    public Integer getPort() {
-        return this.port;
-    }
-
-    public void setPort(Integer port) {
-        this.port = port;
-    }
-
-    public InetAddress getAddress() {
-        return this.address;
-    }
-
-    public void setAddress(InetAddress address) {
-        this.address = address;
-    }
-
-    public Integer getSessionTimeout() {
-        return this.sessionTimeout;
-    }
-
-    public void setSessionTimeout(Integer sessionTimeout) {
-        this.sessionTimeout = sessionTimeout;
-    }
-
-    public Ssl getSsl() {
-        return this.ssl;
-    }
-
-    public void setSsl(Ssl ssl) {
-        this.ssl = ssl;
-    }
-
-    public JspServlet getJspServlet() {
-        return this.jspServlet;
-    }
-
-    public void setJspServlet(JspServlet jspServlet) {
-        this.jspServlet = jspServlet;
-    }
-
-    public Map<String, String> getContextParameters() {
-        return this.contextParameters;
-    }
-
-    public void setLoader(String value) {
-        // no op to support Tomcat running as a traditional container (not embedded)
-    }
-
-    @Override
-    public void customize(ConfigurableEmbeddedServletContainer container) {
-        if (getPort() != null) {
-            container.setPort(getPort());
-        }
-        if (getAddress() != null) {
-            container.setAddress(getAddress());
-        }
-        if (getContextPath() != null) {
-            container.setContextPath(getContextPath());
-        }
-        if (getSessionTimeout() != null) {
-            container.setSessionTimeout(getSessionTimeout());
-        }
-        if (getSsl() != null) {
-            container.setSsl(getSsl());
-        }
-        if (getJspServlet() != null) {
-            container.setJspServlet(getJspServlet());
-        }
-        if (container instanceof TomcatEmbeddedServletContainerFactory) {
-            getTomcat()
-                    .customizeTomcat((TomcatEmbeddedServletContainerFactory) container);
-        }
-        if (container instanceof UndertowEmbeddedServletContainerFactory) {
-            getUndertow().customizeUndertow(
-                    (UndertowEmbeddedServletContainerFactory) container);
-        }
-        container.addInitializers(new InitParameterConfiguringServletContextInitializer(
-                getContextParameters()));
-    }
-
-    public String[] getPathsArray(Collection<String> paths) {
-        String[] result = new String[paths.size()];
-        int i = 0;
-        for (String path : paths) {
-            result[i++] = getPath(path);
-        }
-        return result;
-    }
-
-    public String[] getPathsArray(String[] paths) {
-        String[] result = new String[paths.length];
-        int i = 0;
-        for (String path : paths) {
-            result[i++] = getPath(path);
-        }
-        return result;
-    }
-
-    public String getPath(String path) {
-        String prefix = getServletPrefix();
-        if (!path.startsWith("/")) {
-            path = "/" + path;
-        }
-        return prefix + path;
-    }
-
-    public static class Tomcat {
-
-        /**
-         * Format pattern for access logs.
-         */
-        private String accessLogPattern;
-
-        /**
-         * Enable access log.
-         */
-        private boolean accessLogEnabled = false;
-
-        /**
-         * Regular expression that matches proxies that are to be trusted.
-         */
-        private String internalProxies = "10\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}|" // 10/8
-                + "192\\.168\\.\\d{1,3}\\.\\d{1,3}|" // 192.168/16
-                + "169\\.254\\.\\d{1,3}\\.\\d{1,3}|" // 169.254/16
-                + "127\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"; // 127/8
-
-        /**
-         * Header that holds the incoming protocol, usually named "X-Forwarded-Proto".
-         * Configured as a RemoteIpValve only if remoteIpHeader is also set.
-         */
-        private String protocolHeader;
-
-        /**
-         * Name of the HTTP header used to override the original port value.
-         */
-        private String portHeader;
-
-        /**
-         * Name of the http header from which the remote ip is extracted. Configured as a
-         * RemoteIpValve only if remoteIpHeader is also set.
-         */
-        private String remoteIpHeader;
-
-        /**
-         * Tomcat base directory. If not specified a temporary directory will be used.
-         */
-        private File basedir;
-
-        /**
-         * Delay in seconds between the invocation of backgroundProcess methods.
-         */
-        private int backgroundProcessorDelay = 30; // seconds
-
-        /**
-         * Maximum amount of worker threads.
-         */
-        private int maxThreads = 0; // Number of threads in protocol handler
-
-        /**
-         * Maximum size in bytes of the HTTP message header.
-         */
-        private int maxHttpHeaderSize = 0; // bytes
-
-        /**
-         * Character encoding to use to decode the URI.
-         */
-        private String uriEncoding;
-
-        /**
-         * Controls response compression. Acceptable values are "off" to disable
-         * compression, "on" to enable compression of responses over 2048 bytes, "force"
-         * to force response compression, or an integer value to enable compression of
-         * responses with content length that is at least that value.
-         */
-        private String compression = "off";
-
-        /**
-         * Comma-separated list of MIME types for which compression is used.
-         */
-        private String compressableMimeTypes = "text/html,text/xml,text/plain";
-
-        public int getMaxThreads() {
-            return this.maxThreads;
-        }
-
-        public void setMaxThreads(int maxThreads) {
-            this.maxThreads = maxThreads;
-        }
-
-        public int getMaxHttpHeaderSize() {
-            return this.maxHttpHeaderSize;
-        }
-
-        public void setMaxHttpHeaderSize(int maxHttpHeaderSize) {
-            this.maxHttpHeaderSize = maxHttpHeaderSize;
-        }
-
-        public boolean getAccessLogEnabled() {
-            return this.accessLogEnabled;
-        }
-
-        public void setAccessLogEnabled(boolean accessLogEnabled) {
-            this.accessLogEnabled = accessLogEnabled;
-        }
-
-        public int getBackgroundProcessorDelay() {
-            return this.backgroundProcessorDelay;
-        }
-
-        public void setBackgroundProcessorDelay(int backgroundProcessorDelay) {
-            this.backgroundProcessorDelay = backgroundProcessorDelay;
-        }
-
-        public File getBasedir() {
-            return this.basedir;
-        }
-
-        public void setBasedir(File basedir) {
-            this.basedir = basedir;
-        }
-
-        public String getAccessLogPattern() {
-            return this.accessLogPattern;
-        }
-
-        public void setAccessLogPattern(String accessLogPattern) {
-            this.accessLogPattern = accessLogPattern;
-        }
-
-        public String getCompressableMimeTypes() {
-            return this.compressableMimeTypes;
-        }
-
-        public void setCompressableMimeTypes(String compressableMimeTypes) {
-            this.compressableMimeTypes = compressableMimeTypes;
-        }
-
-        public String getCompression() {
-            return this.compression;
-        }
-
-        public void setCompression(String compression) {
-            this.compression = compression;
-        }
-
-        public String getInternalProxies() {
-            return this.internalProxies;
-        }
-
-        public void setInternalProxies(String internalProxies) {
-            this.internalProxies = internalProxies;
-        }
-
-        public String getProtocolHeader() {
-            return this.protocolHeader;
-        }
-
-        public void setProtocolHeader(String protocolHeader) {
-            this.protocolHeader = protocolHeader;
-        }
-
-        public String getPortHeader() {
-            return this.portHeader;
-        }
-
-        public void setPortHeader(String portHeader) {
-            this.portHeader = portHeader;
-        }
-
-        public String getRemoteIpHeader() {
-            return this.remoteIpHeader;
-        }
-
-        public void setRemoteIpHeader(String remoteIpHeader) {
-            this.remoteIpHeader = remoteIpHeader;
-        }
-
-        public String getUriEncoding() {
-            return this.uriEncoding;
-        }
-
-        public void setUriEncoding(String uriEncoding) {
-            this.uriEncoding = uriEncoding;
-        }
-
-        void customizeTomcat(TomcatEmbeddedServletContainerFactory factory) {
-            if (getBasedir() != null) {
-                factory.setBaseDirectory(getBasedir());
-            }
-
-            factory.addContextCustomizers(new TomcatContextCustomizer() {
-                @Override
-                public void customize(Context context) {
-                    context.setBackgroundProcessorDelay(Tomcat.this.backgroundProcessorDelay);
-                }
-            });
-
-            String remoteIpHeader = getRemoteIpHeader();
-            String protocolHeader = getProtocolHeader();
-            if (StringUtils.hasText(remoteIpHeader)
-                    || StringUtils.hasText(protocolHeader)) {
-                RemoteIpValve valve = new RemoteIpValve();
-                valve.setRemoteIpHeader(remoteIpHeader);
-                valve.setProtocolHeader(protocolHeader);
-                valve.setInternalProxies(getInternalProxies());
-                valve.setPortHeader(getPortHeader());
-                factory.addContextValves(valve);
-            }
-
-            if (this.maxThreads > 0) {
-                factory.addConnectorCustomizers(new TomcatConnectorCustomizer() {
-                    @Override
-                    public void customize(Connector connector) {
-                        ProtocolHandler handler = connector.getProtocolHandler();
-                        if (handler instanceof AbstractProtocol) {
-                            @SuppressWarnings("rawtypes")
-                            AbstractProtocol protocol = (AbstractProtocol) handler;
-                            protocol.setMaxThreads(Tomcat.this.maxThreads);
-                        }
-                    }
-                });
-            }
-
-            if (this.maxHttpHeaderSize > 0) {
-                factory.addConnectorCustomizers(new TomcatConnectorCustomizer() {
-                    @Override
-                    public void customize(Connector connector) {
-                        ProtocolHandler handler = connector.getProtocolHandler();
-                        if (handler instanceof AbstractHttp11Protocol) {
-                            @SuppressWarnings("rawtypes")
-                            AbstractHttp11Protocol protocol = (AbstractHttp11Protocol) handler;
-                            protocol.setMaxHttpHeaderSize(Tomcat.this.maxHttpHeaderSize);
-                        }
-                    }
-                });
-            }
-
-            factory.addConnectorCustomizers(new TomcatConnectorCustomizer() {
-
-                @Override
-                public void customize(Connector connector) {
-                    ProtocolHandler handler = connector.getProtocolHandler();
-                    if (handler instanceof AbstractHttp11Protocol) {
-                        @SuppressWarnings("rawtypes")
-                        AbstractHttp11Protocol protocol = (AbstractHttp11Protocol) handler;
-                        protocol.setCompression(coerceCompression(Tomcat.this.compression));
-                        protocol.setCompressableMimeTypes(Tomcat.this.compressableMimeTypes);
-                    }
-                }
-
-                private String coerceCompression(String compression) {
-                    if ("true".equalsIgnoreCase(compression)) {
-                        return "on";
-                    }
-                    if ("false".equalsIgnoreCase(compression)) {
-                        return "off";
-                    }
-                    return compression;
-                }
-
-            });
-
-            if (this.accessLogEnabled) {
-                AccessLogValve valve = new AccessLogValve();
-                String accessLogPattern = getAccessLogPattern();
-                if (accessLogPattern != null) {
-                    valve.setPattern(accessLogPattern);
-                } else {
-                    valve.setPattern("common");
-                }
-                valve.setSuffix(".log");
-                factory.addContextValves(valve);
-            }
-            if (getUriEncoding() != null) {
-                factory.setUriEncoding(getUriEncoding());
-            }
-        }
-
-    }
-
-    public static class Undertow {
-
-        /**
-         * Size of each buffer in bytes.
-         */
-        private Integer bufferSize;
-
-        /**
-         * Number of buffer per region.
-         */
-        private Integer buffersPerRegion;
-
-        /**
-         * Number of I/O threads to create for the worker.
-         */
-        private Integer ioThreads;
-
-        /**
-         * Number of worker threads.
-         */
-        private Integer workerThreads;
-
-        private Boolean directBuffers;
-
-        /**
-         * Format pattern for access logs.
-         */
-        private String accessLogPattern;
-
-        /**
-         * Enable access log.
-         */
-        private boolean accessLogEnabled = false;
-
-        /**
-         * Undertow base directory. If not specified a temporary directory will be used.
-         */
-        private File basedir;
-
-        public String getAccessLogPattern() {
-            return accessLogPattern;
-        }
-
-        public void setAccessLogPattern(String accessLogPattern) {
-            this.accessLogPattern = accessLogPattern;
-        }
-
-        public boolean isAccessLogEnabled() {
-            return accessLogEnabled;
-        }
-
-        public void setAccessLogEnabled(boolean accessLogEnabled) {
-            this.accessLogEnabled = accessLogEnabled;
-        }
-
-        public File getBasedir() {
-            return basedir;
-        }
-
-        public void setBasedir(File basedir) {
-            this.basedir = basedir;
-        }
-
-        public Integer getBufferSize() {
-            return this.bufferSize;
-        }
-
-        public void setBufferSize(Integer bufferSize) {
-            this.bufferSize = bufferSize;
-        }
-
-        public Integer getBuffersPerRegion() {
-            return this.buffersPerRegion;
-        }
-
-        public void setBuffersPerRegion(Integer buffersPerRegion) {
-            this.buffersPerRegion = buffersPerRegion;
-        }
-
-        public Integer getIoThreads() {
-            return this.ioThreads;
-        }
-
-        public void setIoThreads(Integer ioThreads) {
-            this.ioThreads = ioThreads;
-        }
-
-        public Integer getWorkerThreads() {
-            return this.workerThreads;
-        }
-
-        public void setWorkerThreads(Integer workerThreads) {
-            this.workerThreads = workerThreads;
-        }
-
-        public Boolean getDirectBuffers() {
-            return this.directBuffers;
-        }
-
-        public void setDirectBuffers(Boolean directBuffers) {
-            this.directBuffers = directBuffers;
-        }
-
-        void customizeUndertow(final UndertowEmbeddedServletContainerFactory factory) {
-            factory.setBufferSize(this.bufferSize);
-            factory.setBuffersPerRegion(this.buffersPerRegion);
-            factory.setIoThreads(this.ioThreads);
-            factory.setWorkerThreads(this.workerThreads);
-            factory.setDirectBuffers(this.directBuffers);
-
-            if (isAccessLogEnabled()) {
-                factory.setBaseDirectory(this.basedir);
-                factory.setAccessLogPattern(this.accessLogPattern);
-                factory.setAccessLogEnabled(this.accessLogEnabled);
-            }
-        }
-
-    }
+	private final Tomcat tomcat = new Tomcat();
+	private final Undertow undertow = new Undertow();
+	/**
+	 * ServletContext parameters.
+	 */
+	private final Map<String, String> contextParameters = new HashMap<String, String>();
+	/**
+	 * Server HTTP port.
+	 */
+	private Integer port;
+	/**
+	 * Network address to which the server should bind to.
+	 */
+	private InetAddress address;
+	/**
+	 * Session timeout in seconds.
+	 */
+	private Integer sessionTimeout;
+	/**
+	 * Context path of the application.
+	 */
+	private String contextPath;
+	@NestedConfigurationProperty
+	private Ssl ssl;
+	/**
+	 * Path of the main dispatcher servlet.
+	 */
+	@NotNull
+	private String servletPath = "/";
+	@NestedConfigurationProperty
+	private JspServlet jspServlet;
+
+	@Override
+	public int getOrder() {
+		return 0;
+	}
+
+	public Tomcat getTomcat() {
+		return this.tomcat;
+	}
+
+	public Undertow getUndertow() {
+		return this.undertow;
+	}
+
+	public String getContextPath() {
+		return this.contextPath;
+	}
+
+	public void setContextPath(String contextPath) {
+		this.contextPath = contextPath;
+	}
+
+	public String getServletPath() {
+		return this.servletPath;
+	}
+
+	public void setServletPath(String servletPath) {
+		this.servletPath = servletPath;
+	}
+
+	public String getServletMapping() {
+		if (this.servletPath.equals("") || this.servletPath.equals("/")) {
+			return "/";
+		}
+		if (this.servletPath.contains("*")) {
+			return this.servletPath;
+		}
+		if (this.servletPath.endsWith("/")) {
+			return this.servletPath + "*";
+		}
+		return this.servletPath + "/*";
+	}
+
+	public String getServletPrefix() {
+		String result = this.servletPath;
+		if (result.contains("*")) {
+			result = result.substring(0, result.indexOf("*"));
+		}
+		if (result.endsWith("/")) {
+			result = result.substring(0, result.length() - 1);
+		}
+		return result;
+	}
+
+	public Integer getPort() {
+		return this.port;
+	}
+
+	public void setPort(Integer port) {
+		this.port = port;
+	}
+
+	public InetAddress getAddress() {
+		return this.address;
+	}
+
+	public void setAddress(InetAddress address) {
+		this.address = address;
+	}
+
+	public Integer getSessionTimeout() {
+		return this.sessionTimeout;
+	}
+
+	public void setSessionTimeout(Integer sessionTimeout) {
+		this.sessionTimeout = sessionTimeout;
+	}
+
+	public Ssl getSsl() {
+		return this.ssl;
+	}
+
+	public void setSsl(Ssl ssl) {
+		this.ssl = ssl;
+	}
+
+	public JspServlet getJspServlet() {
+		return this.jspServlet;
+	}
+
+	public void setJspServlet(JspServlet jspServlet) {
+		this.jspServlet = jspServlet;
+	}
+
+	public Map<String, String> getContextParameters() {
+		return this.contextParameters;
+	}
+
+	public void setLoader(String value) {
+		// no op to support Tomcat running as a traditional container (not embedded)
+	}
+
+	@Override
+	public void customize(ConfigurableEmbeddedServletContainer container) {
+		if (getPort() != null) {
+			container.setPort(getPort());
+		}
+		if (getAddress() != null) {
+			container.setAddress(getAddress());
+		}
+		if (getContextPath() != null) {
+			container.setContextPath(getContextPath());
+		}
+		if (getSessionTimeout() != null) {
+			container.setSessionTimeout(getSessionTimeout());
+		}
+		if (getSsl() != null) {
+			container.setSsl(getSsl());
+		}
+		if (getJspServlet() != null) {
+			container.setJspServlet(getJspServlet());
+		}
+		if (container instanceof TomcatEmbeddedServletContainerFactory) {
+			getTomcat()
+					.customizeTomcat((TomcatEmbeddedServletContainerFactory) container);
+		}
+		if (container instanceof UndertowEmbeddedServletContainerFactory) {
+			getUndertow().customizeUndertow(
+					(UndertowEmbeddedServletContainerFactory) container);
+		}
+		container.addInitializers(new InitParameterConfiguringServletContextInitializer(
+				getContextParameters()));
+	}
+
+	public String[] getPathsArray(Collection<String> paths) {
+		String[] result = new String[paths.size()];
+		int i = 0;
+		for (String path : paths) {
+			result[i++] = getPath(path);
+		}
+		return result;
+	}
+
+	public String[] getPathsArray(String[] paths) {
+		String[] result = new String[paths.length];
+		int i = 0;
+		for (String path : paths) {
+			result[i++] = getPath(path);
+		}
+		return result;
+	}
+
+	public String getPath(String path) {
+		String prefix = getServletPrefix();
+		if (!path.startsWith("/")) {
+			path = "/" + path;
+		}
+		return prefix + path;
+	}
+
+	public static class Tomcat {
+
+		/**
+		 * Format pattern for access logs.
+		 */
+		private String accessLogPattern;
+
+		/**
+		 * Enable access log.
+		 */
+		private boolean accessLogEnabled = false;
+
+		/**
+		 * Regular expression that matches proxies that are to be trusted.
+		 */
+		private String internalProxies = "10\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}|" // 10/8
+				+ "192\\.168\\.\\d{1,3}\\.\\d{1,3}|" // 192.168/16
+				+ "169\\.254\\.\\d{1,3}\\.\\d{1,3}|" // 169.254/16
+				+ "127\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"; // 127/8
+
+		/**
+		 * Header that holds the incoming protocol, usually named "X-Forwarded-Proto".
+		 * Configured as a RemoteIpValve only if remoteIpHeader is also set.
+		 */
+		private String protocolHeader;
+
+		/**
+		 * Name of the HTTP header used to override the original port value.
+		 */
+		private String portHeader;
+
+		/**
+		 * Name of the http header from which the remote ip is extracted. Configured as a
+		 * RemoteIpValve only if remoteIpHeader is also set.
+		 */
+		private String remoteIpHeader;
+
+		/**
+		 * Tomcat base directory. If not specified a temporary directory will be used.
+		 */
+		private File basedir;
+
+		/**
+		 * Delay in seconds between the invocation of backgroundProcess methods.
+		 */
+		private int backgroundProcessorDelay = 30; // seconds
+
+		/**
+		 * Maximum amount of worker threads.
+		 */
+		private int maxThreads = 0; // Number of threads in protocol handler
+
+		/**
+		 * Maximum size in bytes of the HTTP message header.
+		 */
+		private int maxHttpHeaderSize = 0; // bytes
+
+		/**
+		 * Character encoding to use to decode the URI.
+		 */
+		private String uriEncoding;
+
+		/**
+		 * Controls response compression. Acceptable values are "off" to disable
+		 * compression, "on" to enable compression of responses over 2048 bytes, "force"
+		 * to force response compression, or an integer value to enable compression of
+		 * responses with content length that is at least that value.
+		 */
+		private String compression = "off";
+
+		/**
+		 * Comma-separated list of MIME types for which compression is used.
+		 */
+		private String compressableMimeTypes = "text/html,text/xml,text/plain";
+
+		public int getMaxThreads() {
+			return this.maxThreads;
+		}
+
+		public void setMaxThreads(int maxThreads) {
+			this.maxThreads = maxThreads;
+		}
+
+		public int getMaxHttpHeaderSize() {
+			return this.maxHttpHeaderSize;
+		}
+
+		public void setMaxHttpHeaderSize(int maxHttpHeaderSize) {
+			this.maxHttpHeaderSize = maxHttpHeaderSize;
+		}
+
+		public boolean getAccessLogEnabled() {
+			return this.accessLogEnabled;
+		}
+
+		public void setAccessLogEnabled(boolean accessLogEnabled) {
+			this.accessLogEnabled = accessLogEnabled;
+		}
+
+		public int getBackgroundProcessorDelay() {
+			return this.backgroundProcessorDelay;
+		}
+
+		public void setBackgroundProcessorDelay(int backgroundProcessorDelay) {
+			this.backgroundProcessorDelay = backgroundProcessorDelay;
+		}
+
+		public File getBasedir() {
+			return this.basedir;
+		}
+
+		public void setBasedir(File basedir) {
+			this.basedir = basedir;
+		}
+
+		public String getAccessLogPattern() {
+			return this.accessLogPattern;
+		}
+
+		public void setAccessLogPattern(String accessLogPattern) {
+			this.accessLogPattern = accessLogPattern;
+		}
+
+		public String getCompressableMimeTypes() {
+			return this.compressableMimeTypes;
+		}
+
+		public void setCompressableMimeTypes(String compressableMimeTypes) {
+			this.compressableMimeTypes = compressableMimeTypes;
+		}
+
+		public String getCompression() {
+			return this.compression;
+		}
+
+		public void setCompression(String compression) {
+			this.compression = compression;
+		}
+
+		public String getInternalProxies() {
+			return this.internalProxies;
+		}
+
+		public void setInternalProxies(String internalProxies) {
+			this.internalProxies = internalProxies;
+		}
+
+		public String getProtocolHeader() {
+			return this.protocolHeader;
+		}
+
+		public void setProtocolHeader(String protocolHeader) {
+			this.protocolHeader = protocolHeader;
+		}
+
+		public String getPortHeader() {
+			return this.portHeader;
+		}
+
+		public void setPortHeader(String portHeader) {
+			this.portHeader = portHeader;
+		}
+
+		public String getRemoteIpHeader() {
+			return this.remoteIpHeader;
+		}
+
+		public void setRemoteIpHeader(String remoteIpHeader) {
+			this.remoteIpHeader = remoteIpHeader;
+		}
+
+		public String getUriEncoding() {
+			return this.uriEncoding;
+		}
+
+		public void setUriEncoding(String uriEncoding) {
+			this.uriEncoding = uriEncoding;
+		}
+
+		void customizeTomcat(TomcatEmbeddedServletContainerFactory factory) {
+			if (getBasedir() != null) {
+				factory.setBaseDirectory(getBasedir());
+			}
+
+			factory.addContextCustomizers(new TomcatContextCustomizer() {
+				@Override
+				public void customize(Context context) {
+					context.setBackgroundProcessorDelay(Tomcat.this.backgroundProcessorDelay);
+				}
+			});
+
+			String remoteIpHeader = getRemoteIpHeader();
+			String protocolHeader = getProtocolHeader();
+			if (StringUtils.hasText(remoteIpHeader)
+					|| StringUtils.hasText(protocolHeader)) {
+				RemoteIpValve valve = new RemoteIpValve();
+				valve.setRemoteIpHeader(remoteIpHeader);
+				valve.setProtocolHeader(protocolHeader);
+				valve.setInternalProxies(getInternalProxies());
+				valve.setPortHeader(getPortHeader());
+				factory.addContextValves(valve);
+			}
+
+			if (this.maxThreads > 0) {
+				factory.addConnectorCustomizers(new TomcatConnectorCustomizer() {
+					@Override
+					public void customize(Connector connector) {
+						ProtocolHandler handler = connector.getProtocolHandler();
+						if (handler instanceof AbstractProtocol) {
+							@SuppressWarnings("rawtypes")
+							AbstractProtocol protocol = (AbstractProtocol) handler;
+							protocol.setMaxThreads(Tomcat.this.maxThreads);
+						}
+					}
+				});
+			}
+
+			if (this.maxHttpHeaderSize > 0) {
+				factory.addConnectorCustomizers(new TomcatConnectorCustomizer() {
+					@Override
+					public void customize(Connector connector) {
+						ProtocolHandler handler = connector.getProtocolHandler();
+						if (handler instanceof AbstractHttp11Protocol) {
+							@SuppressWarnings("rawtypes")
+							AbstractHttp11Protocol protocol = (AbstractHttp11Protocol) handler;
+							protocol.setMaxHttpHeaderSize(Tomcat.this.maxHttpHeaderSize);
+						}
+					}
+				});
+			}
+
+			factory.addConnectorCustomizers(new TomcatConnectorCustomizer() {
+
+				@Override
+				public void customize(Connector connector) {
+					ProtocolHandler handler = connector.getProtocolHandler();
+					if (handler instanceof AbstractHttp11Protocol) {
+						@SuppressWarnings("rawtypes")
+						AbstractHttp11Protocol protocol = (AbstractHttp11Protocol) handler;
+						protocol.setCompression(coerceCompression(Tomcat.this.compression));
+						protocol.setCompressableMimeTypes(Tomcat.this.compressableMimeTypes);
+					}
+				}
+
+				private String coerceCompression(String compression) {
+					if ("true".equalsIgnoreCase(compression)) {
+						return "on";
+					}
+					if ("false".equalsIgnoreCase(compression)) {
+						return "off";
+					}
+					return compression;
+				}
+
+			});
+
+			if (this.accessLogEnabled) {
+				AccessLogValve valve = new AccessLogValve();
+				String accessLogPattern = getAccessLogPattern();
+				if (accessLogPattern != null) {
+					valve.setPattern(accessLogPattern);
+				}
+				else {
+					valve.setPattern("common");
+				}
+				valve.setSuffix(".log");
+				factory.addContextValves(valve);
+			}
+			if (getUriEncoding() != null) {
+				factory.setUriEncoding(getUriEncoding());
+			}
+		}
+
+	}
+
+	public static class Undertow {
+
+		/**
+		 * Size of each buffer in bytes.
+		 */
+		private Integer bufferSize;
+
+		/**
+		 * Number of buffer per region.
+		 */
+		private Integer buffersPerRegion;
+
+		/**
+		 * Number of I/O threads to create for the worker.
+		 */
+		private Integer ioThreads;
+
+		/**
+		 * Number of worker threads.
+		 */
+		private Integer workerThreads;
+
+		private Boolean directBuffers;
+
+		/**
+		 * Format pattern for access logs.
+		 */
+		private String accessLogPattern;
+
+		/**
+		 * Enable access log.
+		 */
+		private boolean accessLogEnabled = false;
+
+		/**
+		 * Undertow base directory. If not specified a temporary directory will be used.
+		 */
+		private File basedir;
+
+		public String getAccessLogPattern() {
+			return accessLogPattern;
+		}
+
+		public void setAccessLogPattern(String accessLogPattern) {
+			this.accessLogPattern = accessLogPattern;
+		}
+
+		public boolean isAccessLogEnabled() {
+			return accessLogEnabled;
+		}
+
+		public void setAccessLogEnabled(boolean accessLogEnabled) {
+			this.accessLogEnabled = accessLogEnabled;
+		}
+
+		public File getBasedir() {
+			return basedir;
+		}
+
+		public void setBasedir(File basedir) {
+			this.basedir = basedir;
+		}
+
+		public Integer getBufferSize() {
+			return this.bufferSize;
+		}
+
+		public void setBufferSize(Integer bufferSize) {
+			this.bufferSize = bufferSize;
+		}
+
+		public Integer getBuffersPerRegion() {
+			return this.buffersPerRegion;
+		}
+
+		public void setBuffersPerRegion(Integer buffersPerRegion) {
+			this.buffersPerRegion = buffersPerRegion;
+		}
+
+		public Integer getIoThreads() {
+			return this.ioThreads;
+		}
+
+		public void setIoThreads(Integer ioThreads) {
+			this.ioThreads = ioThreads;
+		}
+
+		public Integer getWorkerThreads() {
+			return this.workerThreads;
+		}
+
+		public void setWorkerThreads(Integer workerThreads) {
+			this.workerThreads = workerThreads;
+		}
+
+		public Boolean getDirectBuffers() {
+			return this.directBuffers;
+		}
+
+		public void setDirectBuffers(Boolean directBuffers) {
+			this.directBuffers = directBuffers;
+		}
+
+		void customizeUndertow(final UndertowEmbeddedServletContainerFactory factory) {
+			factory.setBufferSize(this.bufferSize);
+			factory.setBuffersPerRegion(this.buffersPerRegion);
+			factory.setIoThreads(this.ioThreads);
+			factory.setWorkerThreads(this.workerThreads);
+			factory.setDirectBuffers(this.directBuffers);
+
+			if (isAccessLogEnabled()) {
+				factory.setBaseDirectory(this.basedir);
+				factory.setAccessLogPattern(this.accessLogPattern);
+				factory.setAccessLogEnabled(this.accessLogEnabled);
+			}
+		}
+
+	}
 
 }

--- a/spring-boot-samples/pom.xml
+++ b/spring-boot-samples/pom.xml
@@ -68,6 +68,7 @@
 		<module>spring-boot-sample-tomcat7-jsp</module>
 		<module>spring-boot-sample-traditional</module>
 		<module>spring-boot-sample-undertow</module>
+		<module>spring-boot-sample-undertow-access-log</module>
 		<module>spring-boot-sample-undertow-ssl</module>
 		<module>spring-boot-sample-velocity</module>
 		<module>spring-boot-sample-web-freemarker</module>

--- a/spring-boot-samples/spring-boot-sample-undertow-access-log/pom.xml
+++ b/spring-boot-samples/spring-boot-sample-undertow-access-log/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<!-- Your own application should inherit from spring-boot-starter-parent -->
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-samples</artifactId>
+		<version>1.3.0.BUILD-SNAPSHOT</version>
+	</parent>
+	<artifactId>spring-boot-sample-undertow-access-log</artifactId>
+	<name>Spring Boot Undertow Sample</name>
+	<description>Spring Boot Undertow Sample</description>
+	<url>http://projects.spring.io/spring-boot/</url>
+	<organization>
+		<name>Pivotal Software, Inc.</name>
+		<url>http://www.spring.io</url>
+	</organization>
+	<properties>
+		<main.basedir>${basedir}/../..</main.basedir>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+		 <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-tomcat</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-undertow</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-webmvc</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/spring-boot-samples/spring-boot-sample-undertow-access-log/src/main/java/sample/undertow/SampleUndertowAccessLogApplication.java
+++ b/spring-boot-samples/spring-boot-sample-undertow-access-log/src/main/java/sample/undertow/SampleUndertowAccessLogApplication.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample.undertow;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class SampleUndertowAccessLogApplication {
+
+	public static void main(String[] args) throws Exception {
+		SpringApplication.run(SampleUndertowAccessLogApplication.class, args);
+	}
+
+}

--- a/spring-boot-samples/spring-boot-sample-undertow-access-log/src/main/java/sample/undertow/service/HelloWorldService.java
+++ b/spring-boot-samples/spring-boot-sample-undertow-access-log/src/main/java/sample/undertow/service/HelloWorldService.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample.undertow.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class HelloWorldService {
+
+	@Value("${name:World}")
+	private String name;
+
+	public String getHelloMessage() {
+		return "Hello " + this.name;
+	}
+
+}

--- a/spring-boot-samples/spring-boot-sample-undertow-access-log/src/main/java/sample/undertow/web/SampleController.java
+++ b/spring-boot-samples/spring-boot-sample-undertow-access-log/src/main/java/sample/undertow/web/SampleController.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample.undertow.web;
+
+import java.util.concurrent.Callable;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import sample.undertow.service.HelloWorldService;
+
+@RestController
+public class SampleController {
+
+	@Autowired
+	private HelloWorldService helloWorldService;
+
+	@RequestMapping("/")
+	public String helloWorld() {
+		return this.helloWorldService.getHelloMessage();
+	}
+
+	@RequestMapping("/async")
+	public Callable<String> helloWorldAsync() {
+		return new Callable<String>() {
+
+			@Override
+			public String call() throws Exception {
+				return "async: "
+						+ SampleController.this.helloWorldService.getHelloMessage();
+			}
+
+		};
+
+	}
+
+}

--- a/spring-boot-samples/spring-boot-sample-undertow-access-log/src/main/resources/application.properties
+++ b/spring-boot-samples/spring-boot-sample-undertow-access-log/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+server.port=8080
+server.undertow.access-log-enabled=true

--- a/spring-boot-samples/spring-boot-sample-undertow-access-log/src/test/java/sample/undertow/SampleUndertowApplicationTests.java
+++ b/spring-boot-samples/spring-boot-sample-undertow-access-log/src/test/java/sample/undertow/SampleUndertowApplicationTests.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample.undertow;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.IntegrationTest;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.TestRestTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Basic integration tests for demo application.
+ *
+ * @author Ivan Sopov
+ * @author Andy Wilkinson
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = SampleUndertowAccessLogApplication.class)
+@WebAppConfiguration
+@IntegrationTest("server.port:0")
+@DirtiesContext
+public class SampleUndertowApplicationTests {
+
+	@Value("${local.server.port}")
+	private int port;
+
+	@Test
+	public void testHome() throws Exception {
+		assertOkResponse("/", "Hello World");
+	}
+
+	@Test
+	public void testAsync() throws Exception {
+		assertOkResponse("/async", "async: Hello World");
+	}
+
+	private void assertOkResponse(String path, String body) {
+		ResponseEntity<String> entity = new TestRestTemplate().getForEntity(
+				"http://localhost:" + this.port + path, String.class);
+		assertEquals(HttpStatus.OK, entity.getStatusCode());
+		assertEquals(body, entity.getBody());
+	}
+
+}

--- a/spring-boot/src/main/java/org/springframework/boot/context/embedded/AbstractEmbeddedServletContainerFactory.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/embedded/AbstractEmbeddedServletContainerFactory.java
@@ -32,6 +32,7 @@ import org.apache.commons.logging.LogFactory;
  *
  * @author Phillip Webb
  * @author Dave Syer
+ * @author Marcos Barbero
  */
 public abstract class AbstractEmbeddedServletContainerFactory extends
 		AbstractConfigurableEmbeddedServletContainer implements
@@ -52,6 +53,25 @@ public abstract class AbstractEmbeddedServletContainerFactory extends
 
 	public AbstractEmbeddedServletContainerFactory(String contextPath, int port) {
 		super(contextPath, port);
+	}
+
+	/**
+	 * Create the embedded container temp dir if none is set.
+	 * @param prefix embedded container prefix
+	 * @return the temp dir.
+	 */
+	protected File createTempDir(String prefix) {
+		try {
+			File tempFolder = File.createTempFile(prefix + ".", "." + getPort());
+			tempFolder.delete();
+			tempFolder.mkdir();
+			tempFolder.deleteOnExit();
+			return tempFolder;
+		}
+		catch (IOException ex) {
+			throw new EmbeddedServletContainerException(
+					"Unable to create Tomcat tempdir", ex);
+		}
 	}
 
 	/**

--- a/spring-boot/src/main/java/org/springframework/boot/context/embedded/tomcat/TomcatEmbeddedServletContainerFactory.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/embedded/tomcat/TomcatEmbeddedServletContainerFactory.java
@@ -79,6 +79,8 @@ import org.springframework.util.StringUtils;
  * @author Brock Mills
  * @author Stephane Nicoll
  * @author Andy Wilkinson
+ * @author Marcos Barbero
+ *
  * @see #setPort(int)
  * @see #setContextLifecycleListeners(Collection)
  * @see TomcatEmbeddedServletContainer

--- a/spring-boot/src/main/java/org/springframework/boot/context/embedded/tomcat/TomcatEmbeddedServletContainerFactory.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/embedded/tomcat/TomcatEmbeddedServletContainerFactory.java
@@ -381,20 +381,6 @@ public class TomcatEmbeddedServletContainerFactory extends
 		return new TomcatEmbeddedServletContainer(tomcat, getPort() >= 0);
 	}
 
-	private File createTempDir(String prefix) {
-		try {
-			File tempFolder = File.createTempFile(prefix + ".", "." + getPort());
-			tempFolder.delete();
-			tempFolder.mkdir();
-			tempFolder.deleteOnExit();
-			return tempFolder;
-		}
-		catch (IOException ex) {
-			throw new EmbeddedServletContainerException(
-					"Unable to create Tomcat tempdir", ex);
-		}
-	}
-
 	@Override
 	public void setResourceLoader(ResourceLoader resourceLoader) {
 		this.resourceLoader = resourceLoader;

--- a/spring-boot/src/main/java/org/springframework/boot/context/embedded/undertow/UndertowEmbeddedServletContainerFactory.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/embedded/undertow/UndertowEmbeddedServletContainerFactory.java
@@ -19,51 +19,15 @@ package org.springframework.boot.context.embedded.undertow;
 import io.undertow.Undertow;
 import io.undertow.Undertow.Builder;
 import io.undertow.UndertowMessages;
-import io.undertow.server.handlers.resource.ClassPathResourceManager;
-import io.undertow.server.handlers.resource.FileResourceManager;
-import io.undertow.server.handlers.resource.Resource;
-import io.undertow.server.handlers.resource.ResourceChangeListener;
-import io.undertow.server.handlers.resource.ResourceManager;
-import io.undertow.server.handlers.resource.URLResource;
+import io.undertow.server.handlers.resource.*;
 import io.undertow.server.session.SessionManager;
 import io.undertow.servlet.Servlets;
-import io.undertow.servlet.api.DeploymentInfo;
-import io.undertow.servlet.api.DeploymentManager;
-import io.undertow.servlet.api.MimeMapping;
-import io.undertow.servlet.api.ServletContainerInitializerInfo;
-import io.undertow.servlet.api.ServletStackTraces;
+import io.undertow.servlet.api.*;
 import io.undertow.servlet.handlers.DefaultServlet;
 import io.undertow.servlet.util.ImmediateInstanceFactory;
-
-import java.io.File;
-import java.io.IOException;
-import java.net.URL;
-import java.security.KeyManagementException;
-import java.security.KeyStore;
-import java.security.NoSuchAlgorithmException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
-
-import javax.net.ssl.KeyManager;
-import javax.net.ssl.KeyManagerFactory;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.TrustManagerFactory;
-import javax.servlet.ServletContainerInitializer;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
-
-import org.springframework.boot.context.embedded.AbstractEmbeddedServletContainerFactory;
-import org.springframework.boot.context.embedded.EmbeddedServletContainer;
-import org.springframework.boot.context.embedded.EmbeddedServletContainerFactory;
+import org.springframework.boot.context.embedded.*;
 import org.springframework.boot.context.embedded.ErrorPage;
 import org.springframework.boot.context.embedded.MimeMappings.Mapping;
-import org.springframework.boot.context.embedded.ServletContextInitializer;
-import org.springframework.boot.context.embedded.Ssl;
 import org.springframework.boot.context.embedded.Ssl.ClientAuth;
 import org.springframework.context.ResourceLoaderAware;
 import org.springframework.core.io.ResourceLoader;
@@ -71,6 +35,18 @@ import org.springframework.util.Assert;
 import org.springframework.util.ResourceUtils;
 import org.xnio.Options;
 import org.xnio.SslClientAuthMode;
+
+import javax.net.ssl.*;
+import javax.servlet.ServletContainerInitializer;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.NoSuchAlgorithmException;
+import java.util.*;
 
 /**
  * {@link EmbeddedServletContainerFactory} that can be used to create
@@ -81,433 +57,471 @@ import org.xnio.SslClientAuthMode;
  *
  * @author Ivan Sopov
  * @author Andy Wilkinson
- * @since 1.2.0
+ * @author Marcos Barbero
  * @see UndertowEmbeddedServletContainer
+ * @since 1.2.0
  */
 public class UndertowEmbeddedServletContainerFactory extends
-		AbstractEmbeddedServletContainerFactory implements ResourceLoaderAware {
+        AbstractEmbeddedServletContainerFactory implements ResourceLoaderAware {
 
-	private static final Set<Class<?>> NO_CLASSES = Collections.emptySet();
+    private static final Set<Class<?>> NO_CLASSES = Collections.emptySet();
 
-	private List<UndertowBuilderCustomizer> builderCustomizers = new ArrayList<UndertowBuilderCustomizer>();
+    private List<UndertowBuilderCustomizer> builderCustomizers = new ArrayList<UndertowBuilderCustomizer>();
 
-	private List<UndertowDeploymentInfoCustomizer> deploymentInfoCustomizers = new ArrayList<UndertowDeploymentInfoCustomizer>();
+    private List<UndertowDeploymentInfoCustomizer> deploymentInfoCustomizers = new ArrayList<UndertowDeploymentInfoCustomizer>();
 
-	private ResourceLoader resourceLoader;
+    private ResourceLoader resourceLoader;
 
-	private Integer bufferSize;
+    private Integer bufferSize;
 
-	private Integer buffersPerRegion;
+    private Integer buffersPerRegion;
 
-	private Integer ioThreads;
+    private Integer ioThreads;
 
-	private Integer workerThreads;
+    private Integer workerThreads;
 
-	private Boolean directBuffers;
+    private Boolean directBuffers;
 
-	/**
-	 * Create a new {@link UndertowEmbeddedServletContainerFactory} instance.
-	 */
-	public UndertowEmbeddedServletContainerFactory() {
-		super();
-		getJspServlet().setRegistered(false);
-	}
+    private File baseDirectory;
 
-	/**
-	 * Create a new {@link UndertowEmbeddedServletContainerFactory} that listens for
-	 * requests using the specified port.
-	 * @param port the port to listen on
-	 */
-	public UndertowEmbeddedServletContainerFactory(int port) {
-		super(port);
-		getJspServlet().setRegistered(false);
-	}
+    private String accessLogPattern;
 
-	/**
-	 * Create a new {@link UndertowEmbeddedServletContainerFactory} with the specified
-	 * context path and port.
-	 * @param contextPath root the context path
-	 * @param port the port to listen on
-	 */
-	public UndertowEmbeddedServletContainerFactory(String contextPath, int port) {
-		super(contextPath, port);
-		getJspServlet().setRegistered(false);
-	}
+    /**
+     * Create a new {@link UndertowEmbeddedServletContainerFactory} instance.
+     */
+    public UndertowEmbeddedServletContainerFactory() {
+        super();
+        getJspServlet().setRegistered(false);
+    }
 
-	/**
-	 * Set {@link UndertowBuilderCustomizer}s that should be applied to the Undertow
-	 * {@link Builder}. Calling this method will replace any existing customizers.
-	 * @param customizers the customizers to set
-	 */
-	public void setBuilderCustomizers(
-			Collection<? extends UndertowBuilderCustomizer> customizers) {
-		Assert.notNull(customizers, "Customizers must not be null");
-		this.builderCustomizers = new ArrayList<UndertowBuilderCustomizer>(customizers);
-	}
+    /**
+     * Create a new {@link UndertowEmbeddedServletContainerFactory} that listens for
+     * requests using the specified port.
+     *
+     * @param port the port to listen on
+     */
+    public UndertowEmbeddedServletContainerFactory(int port) {
+        super(port);
+        getJspServlet().setRegistered(false);
+    }
 
-	/**
-	 * Returns a mutable collection of the {@link UndertowBuilderCustomizer}s that will be
-	 * applied to the Undertow {@link Builder} .
-	 * @return the customizers that will be applied
-	 */
-	public Collection<UndertowBuilderCustomizer> getBuilderCustomizers() {
-		return this.builderCustomizers;
-	}
+    /**
+     * Create a new {@link UndertowEmbeddedServletContainerFactory} with the specified
+     * context path and port.
+     *
+     * @param contextPath root the context path
+     * @param port        the port to listen on
+     */
+    public UndertowEmbeddedServletContainerFactory(String contextPath, int port) {
+        super(contextPath, port);
+        getJspServlet().setRegistered(false);
+    }
 
-	/**
-	 * Add {@link UndertowBuilderCustomizer}s that should be used to customize the
-	 * Undertow {@link Builder}.
-	 * @param customizers the customizers to add
-	 */
-	public void addBuilderCustomizers(UndertowBuilderCustomizer... customizers) {
-		Assert.notNull(customizers, "Customizers must not be null");
-		this.builderCustomizers.addAll(Arrays.asList(customizers));
-	}
+    /**
+     * Returns a mutable collection of the {@link UndertowBuilderCustomizer}s that will be
+     * applied to the Undertow {@link Builder} .
+     *
+     * @return the customizers that will be applied
+     */
+    public Collection<UndertowBuilderCustomizer> getBuilderCustomizers() {
+        return this.builderCustomizers;
+    }
 
-	/**
-	 * Set {@link UndertowDeploymentInfoCustomizer}s that should be applied to the
-	 * Undertow {@link DeploymentInfo}. Calling this method will replace any existing
-	 * customizers.
-	 * @param customizers the customizers to set
-	 */
-	public void setDeploymentInfoCustomizers(
-			Collection<? extends UndertowDeploymentInfoCustomizer> customizers) {
-		Assert.notNull(customizers, "Customizers must not be null");
-		this.deploymentInfoCustomizers = new ArrayList<UndertowDeploymentInfoCustomizer>(
-				customizers);
-	}
+    /**
+     * Set {@link UndertowBuilderCustomizer}s that should be applied to the Undertow
+     * {@link Builder}. Calling this method will replace any existing customizers.
+     *
+     * @param customizers the customizers to set
+     */
+    public void setBuilderCustomizers(
+            Collection<? extends UndertowBuilderCustomizer> customizers) {
+        Assert.notNull(customizers, "Customizers must not be null");
+        this.builderCustomizers = new ArrayList<UndertowBuilderCustomizer>(customizers);
+    }
 
-	/**
-	 * Returns a mutable collection of the {@link UndertowDeploymentInfoCustomizer}s that
-	 * will be applied to the Undertow {@link DeploymentInfo} .
-	 * @return the customizers that will be applied
-	 */
-	public Collection<UndertowDeploymentInfoCustomizer> getDeploymentInfoCustomizers() {
-		return this.deploymentInfoCustomizers;
-	}
+    /**
+     * Add {@link UndertowBuilderCustomizer}s that should be used to customize the
+     * Undertow {@link Builder}.
+     *
+     * @param customizers the customizers to add
+     */
+    public void addBuilderCustomizers(UndertowBuilderCustomizer... customizers) {
+        Assert.notNull(customizers, "Customizers must not be null");
+        this.builderCustomizers.addAll(Arrays.asList(customizers));
+    }
 
-	/**
-	 * Add {@link UndertowDeploymentInfoCustomizer}s that should be used to customize the
-	 * Undertow {@link DeploymentInfo}.
-	 * @param customizers the customizers to add
-	 */
-	public void addDeploymentInfoCustomizers(
-			UndertowDeploymentInfoCustomizer... customizers) {
-		Assert.notNull(customizers, "UndertowDeploymentInfoCustomizers must not be null");
-		this.deploymentInfoCustomizers.addAll(Arrays.asList(customizers));
-	}
+    /**
+     * Returns a mutable collection of the {@link UndertowDeploymentInfoCustomizer}s that
+     * will be applied to the Undertow {@link DeploymentInfo} .
+     *
+     * @return the customizers that will be applied
+     */
+    public Collection<UndertowDeploymentInfoCustomizer> getDeploymentInfoCustomizers() {
+        return this.deploymentInfoCustomizers;
+    }
 
-	@Override
-	public EmbeddedServletContainer getEmbeddedServletContainer(
-			ServletContextInitializer... initializers) {
-		DeploymentManager manager = createDeploymentManager(initializers);
-		int port = getPort();
-		Builder builder = createBuilder(port);
-		return new UndertowEmbeddedServletContainer(builder, manager, getContextPath(),
-				port, port >= 0);
-	}
+    /**
+     * Set {@link UndertowDeploymentInfoCustomizer}s that should be applied to the
+     * Undertow {@link DeploymentInfo}. Calling this method will replace any existing
+     * customizers.
+     *
+     * @param customizers the customizers to set
+     */
+    public void setDeploymentInfoCustomizers(
+            Collection<? extends UndertowDeploymentInfoCustomizer> customizers) {
+        Assert.notNull(customizers, "Customizers must not be null");
+        this.deploymentInfoCustomizers = new ArrayList<UndertowDeploymentInfoCustomizer>(
+                customizers);
+    }
 
-	private Builder createBuilder(int port) {
-		Builder builder = Undertow.builder();
-		if (this.bufferSize != null) {
-			builder.setBufferSize(this.bufferSize);
-		}
-		if (this.buffersPerRegion != null) {
-			builder.setBuffersPerRegion(this.buffersPerRegion);
-		}
-		if (this.ioThreads != null) {
-			builder.setIoThreads(this.ioThreads);
-		}
-		if (this.workerThreads != null) {
-			builder.setWorkerThreads(this.workerThreads);
-		}
-		if (this.directBuffers != null) {
-			builder.setDirectBuffers(this.directBuffers);
-		}
-		if (getSsl() != null && getSsl().isEnabled()) {
-			configureSsl(getSsl(), port, builder);
-		}
-		else {
-			builder.addHttpListener(port, getListenAddress());
-		}
-		for (UndertowBuilderCustomizer customizer : this.builderCustomizers) {
-			customizer.customize(builder);
-		}
-		return builder;
-	}
+    /**
+     * Add {@link UndertowDeploymentInfoCustomizer}s that should be used to customize the
+     * Undertow {@link DeploymentInfo}.
+     *
+     * @param customizers the customizers to add
+     */
+    public void addDeploymentInfoCustomizers(
+            UndertowDeploymentInfoCustomizer... customizers) {
+        Assert.notNull(customizers, "UndertowDeploymentInfoCustomizers must not be null");
+        this.deploymentInfoCustomizers.addAll(Arrays.asList(customizers));
+    }
 
-	private void configureSsl(Ssl ssl, int port, Builder builder) {
-		try {
-			SSLContext sslContext = SSLContext.getInstance(ssl.getProtocol());
-			sslContext.init(getKeyManagers(), getTrustManagers(), null);
-			builder.addHttpsListener(port, getListenAddress(), sslContext);
-			builder.setSocketOption(Options.SSL_CLIENT_AUTH_MODE,
-					getSslClientAuthMode(ssl));
-		}
-		catch (NoSuchAlgorithmException ex) {
-			throw new IllegalStateException(ex);
-		}
-		catch (KeyManagementException ex) {
-			throw new IllegalStateException(ex);
-		}
-	}
+    /**
+     * Set the Undertow base directory. If not specified a temporary directory will be used.
+     *
+     * @param baseDirectory the tomcat base directory
+     */
+    public void setBaseDirectory(File baseDirectory) {
+        this.baseDirectory = baseDirectory;
+    }
 
-	private String getListenAddress() {
-		if (getAddress() == null) {
-			return "0.0.0.0";
-		}
-		return getAddress().getHostAddress();
-	}
+    /**
+     * Set the access log pattern.
+     *
+     * @param accessLogPattern
+     */
+    public void setAccessLogPattern(String accessLogPattern) {
+        this.accessLogPattern = accessLogPattern;
+    }
 
-	private SslClientAuthMode getSslClientAuthMode(Ssl ssl) {
-		if (ssl.getClientAuth() == ClientAuth.NEED) {
-			return SslClientAuthMode.REQUIRED;
-		}
-		if (ssl.getClientAuth() == ClientAuth.WANT) {
-			return SslClientAuthMode.REQUESTED;
-		}
-		return SslClientAuthMode.NOT_REQUESTED;
-	}
+    @Override
+    public EmbeddedServletContainer getEmbeddedServletContainer(
+            ServletContextInitializer... initializers) {
+        DeploymentManager manager = createDeploymentManager(initializers);
+        int port = getPort();
+        File baseDir = (this.baseDirectory != null ? this.baseDirectory
+                : createTempDir("undertow"));
 
-	private KeyManager[] getKeyManagers() {
-		try {
-			Ssl ssl = getSsl();
-			String keyStoreType = ssl.getKeyStoreType();
-			if (keyStoreType == null) {
-				keyStoreType = "JKS";
-			}
-			KeyStore keyStore = KeyStore.getInstance(keyStoreType);
-			URL url = ResourceUtils.getURL(ssl.getKeyStore());
-			keyStore.load(url.openStream(), ssl.getKeyStorePassword().toCharArray());
+//		Undertow undertow = new Undertow();
+//		tomcat.setBaseDir(baseDir.getAbsolutePath());
 
-			// Get key manager to provide client credentials.
-			KeyManagerFactory keyManagerFactory = KeyManagerFactory
-					.getInstance(KeyManagerFactory.getDefaultAlgorithm());
-			char[] keyPassword = ssl.getKeyPassword() != null ? ssl.getKeyPassword()
-					.toCharArray() : ssl.getKeyStorePassword().toCharArray();
-			keyManagerFactory.init(keyStore, keyPassword);
-			return keyManagerFactory.getKeyManagers();
-		}
-		catch (Exception ex) {
-			throw new IllegalStateException(ex);
-		}
-	}
+        Builder builder = createBuilder(port);
 
-	private TrustManager[] getTrustManagers() {
-		try {
-			Ssl ssl = getSsl();
-			String trustStoreType = ssl.getTrustStoreType();
-			if (trustStoreType == null) {
-				trustStoreType = "JKS";
-			}
-			String trustStore = ssl.getTrustStore();
-			if (trustStore == null) {
-				return null;
-			}
-			KeyStore trustedKeyStore = KeyStore.getInstance(trustStoreType);
-			URL url = ResourceUtils.getURL(trustStore);
-			trustedKeyStore.load(url.openStream(), ssl.getTrustStorePassword()
-					.toCharArray());
-			TrustManagerFactory trustManagerFactory = TrustManagerFactory
-					.getInstance(TrustManagerFactory.getDefaultAlgorithm());
-			trustManagerFactory.init(trustedKeyStore);
-			return trustManagerFactory.getTrustManagers();
-		}
-		catch (Exception ex) {
-			throw new IllegalStateException(ex);
-		}
-	}
 
-	private DeploymentManager createDeploymentManager(
-			ServletContextInitializer... initializers) {
-		DeploymentInfo deployment = Servlets.deployment();
-		registerServletContainerInitializerToDriveServletContextInitializers(deployment,
-				initializers);
-		deployment.setClassLoader(getServletClassLoader());
-		deployment.setContextPath(getContextPath());
-		deployment.setDeploymentName("spring-boot");
-		if (isRegisterDefaultServlet()) {
-			deployment.addServlet(Servlets.servlet("default", DefaultServlet.class));
-		}
-		configureErrorPages(deployment);
-		deployment.setServletStackTraces(ServletStackTraces.NONE);
-		deployment.setResourceManager(getDocumentRootResourceManager());
-		configureMimeMappings(deployment);
-		for (UndertowDeploymentInfoCustomizer customizer : this.deploymentInfoCustomizers) {
-			customizer.customize(deployment);
-		}
-		DeploymentManager manager = Servlets.defaultContainer().addDeployment(deployment);
-		manager.deploy();
-		SessionManager sessionManager = manager.getDeployment().getSessionManager();
-		int sessionTimeout = (getSessionTimeout() > 0 ? getSessionTimeout() : -1);
-		sessionManager.setDefaultSessionTimeout(sessionTimeout);
-		return manager;
-	}
 
-	private void registerServletContainerInitializerToDriveServletContextInitializers(
-			DeploymentInfo deployment, ServletContextInitializer... initializers) {
-		ServletContextInitializer[] mergedInitializers = mergeInitializers(initializers);
-		Initializer initializer = new Initializer(mergedInitializers);
-		deployment.addServletContainerInitalizer(new ServletContainerInitializerInfo(
-				Initializer.class,
-				new ImmediateInstanceFactory<ServletContainerInitializer>(initializer),
-				NO_CLASSES));
-	}
+        UndertowEmbeddedServletContainer container = new UndertowEmbeddedServletContainer(builder, manager, getContextPath(),
+                port, port >= 0);
 
-	private ClassLoader getServletClassLoader() {
-		if (this.resourceLoader != null) {
-			return this.resourceLoader.getClassLoader();
-		}
-		return getClass().getClassLoader();
-	}
+        return container;
+    }
 
-	private ResourceManager getDocumentRootResourceManager() {
-		File root = getValidDocumentRoot();
-		if (root != null && root.isDirectory()) {
-			return new FileResourceManager(root, 0);
-		}
-		if (root != null && root.isFile()) {
-			return new JarResourcemanager(root);
-		}
-		if (this.resourceLoader != null) {
-			return new ClassPathResourceManager(this.resourceLoader.getClassLoader(), "");
-		}
-		return new ClassPathResourceManager(getClass().getClassLoader(), "");
-	}
+    private Builder createBuilder(int port) {
+        Builder builder = Undertow.builder();
+        if (this.bufferSize != null) {
+            builder.setBufferSize(this.bufferSize);
+        }
+        if (this.buffersPerRegion != null) {
+            builder.setBuffersPerRegion(this.buffersPerRegion);
+        }
+        if (this.ioThreads != null) {
+            builder.setIoThreads(this.ioThreads);
+        }
+        if (this.workerThreads != null) {
+            builder.setWorkerThreads(this.workerThreads);
+        }
+        if (this.directBuffers != null) {
+            builder.setDirectBuffers(this.directBuffers);
+        }
+        if (getSsl() != null && getSsl().isEnabled()) {
+            configureSsl(getSsl(), port, builder);
+        } else {
+            builder.addHttpListener(port, getListenAddress());
+        }
+        for (UndertowBuilderCustomizer customizer : this.builderCustomizers) {
+            customizer.customize(builder);
+        }
+        return builder;
+    }
 
-	private void configureErrorPages(DeploymentInfo servletBuilder) {
-		for (ErrorPage errorPage : getErrorPages()) {
-			servletBuilder.addErrorPage(getUndertowErrorPage(errorPage));
-		}
-	}
+    private void configureSsl(Ssl ssl, int port, Builder builder) {
+        try {
+            SSLContext sslContext = SSLContext.getInstance(ssl.getProtocol());
+            sslContext.init(getKeyManagers(), getTrustManagers(), null);
+            builder.addHttpsListener(port, getListenAddress(), sslContext);
+            builder.setSocketOption(Options.SSL_CLIENT_AUTH_MODE,
+                    getSslClientAuthMode(ssl));
+        } catch (NoSuchAlgorithmException ex) {
+            throw new IllegalStateException(ex);
+        } catch (KeyManagementException ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
 
-	private io.undertow.servlet.api.ErrorPage getUndertowErrorPage(ErrorPage errorPage) {
-		if (errorPage.getStatus() != null) {
-			return new io.undertow.servlet.api.ErrorPage(errorPage.getPath(),
-					errorPage.getStatusCode());
-		}
-		if (errorPage.getException() != null) {
-			return new io.undertow.servlet.api.ErrorPage(errorPage.getPath(),
-					errorPage.getException());
-		}
-		return new io.undertow.servlet.api.ErrorPage(errorPage.getPath());
-	}
+    private String getListenAddress() {
+        if (getAddress() == null) {
+            return "0.0.0.0";
+        }
+        return getAddress().getHostAddress();
+    }
 
-	private void configureMimeMappings(DeploymentInfo servletBuilder) {
-		for (Mapping mimeMapping : getMimeMappings()) {
-			servletBuilder.addMimeMapping(new MimeMapping(mimeMapping.getExtension(),
-					mimeMapping.getMimeType()));
-		}
-	}
+    private SslClientAuthMode getSslClientAuthMode(Ssl ssl) {
+        if (ssl.getClientAuth() == ClientAuth.NEED) {
+            return SslClientAuthMode.REQUIRED;
+        }
+        if (ssl.getClientAuth() == ClientAuth.WANT) {
+            return SslClientAuthMode.REQUESTED;
+        }
+        return SslClientAuthMode.NOT_REQUESTED;
+    }
 
-	/**
-	 * Factory method called to create the {@link UndertowEmbeddedServletContainer}.
-	 * Subclasses can override this method to return a different
-	 * {@link UndertowEmbeddedServletContainer} or apply additional processing to the
-	 * {@link Builder} and {@link DeploymentManager} used to bootstrap Undertow
-	 * @param builder the builder
-	 * @param manager the deployment manager
-	 * @param port the port that Undertow should listen on
-	 * @return a new {@link UndertowEmbeddedServletContainer} instance
-	 */
-	protected UndertowEmbeddedServletContainer getUndertowEmbeddedServletContainer(
-			Builder builder, DeploymentManager manager, int port) {
-		return new UndertowEmbeddedServletContainer(builder, manager, getContextPath(),
-				port, port >= 0);
-	}
+    private KeyManager[] getKeyManagers() {
+        try {
+            Ssl ssl = getSsl();
+            String keyStoreType = ssl.getKeyStoreType();
+            if (keyStoreType == null) {
+                keyStoreType = "JKS";
+            }
+            KeyStore keyStore = KeyStore.getInstance(keyStoreType);
+            URL url = ResourceUtils.getURL(ssl.getKeyStore());
+            keyStore.load(url.openStream(), ssl.getKeyStorePassword().toCharArray());
 
-	@Override
-	public void setResourceLoader(ResourceLoader resourceLoader) {
-		this.resourceLoader = resourceLoader;
-	}
+            // Get key manager to provide client credentials.
+            KeyManagerFactory keyManagerFactory = KeyManagerFactory
+                    .getInstance(KeyManagerFactory.getDefaultAlgorithm());
+            char[] keyPassword = ssl.getKeyPassword() != null ? ssl.getKeyPassword()
+                    .toCharArray() : ssl.getKeyStorePassword().toCharArray();
+            keyManagerFactory.init(keyStore, keyPassword);
+            return keyManagerFactory.getKeyManagers();
+        } catch (Exception ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
 
-	public void setBufferSize(Integer bufferSize) {
-		this.bufferSize = bufferSize;
-	}
+    private TrustManager[] getTrustManagers() {
+        try {
+            Ssl ssl = getSsl();
+            String trustStoreType = ssl.getTrustStoreType();
+            if (trustStoreType == null) {
+                trustStoreType = "JKS";
+            }
+            String trustStore = ssl.getTrustStore();
+            if (trustStore == null) {
+                return null;
+            }
+            KeyStore trustedKeyStore = KeyStore.getInstance(trustStoreType);
+            URL url = ResourceUtils.getURL(trustStore);
+            trustedKeyStore.load(url.openStream(), ssl.getTrustStorePassword()
+                    .toCharArray());
+            TrustManagerFactory trustManagerFactory = TrustManagerFactory
+                    .getInstance(TrustManagerFactory.getDefaultAlgorithm());
+            trustManagerFactory.init(trustedKeyStore);
+            return trustManagerFactory.getTrustManagers();
+        } catch (Exception ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
 
-	public void setBuffersPerRegion(Integer buffersPerRegion) {
-		this.buffersPerRegion = buffersPerRegion;
-	}
+    private DeploymentManager createDeploymentManager(
+            ServletContextInitializer... initializers) {
+        DeploymentInfo deployment = Servlets.deployment();
+        registerServletContainerInitializerToDriveServletContextInitializers(deployment,
+                initializers);
+        deployment.setClassLoader(getServletClassLoader());
+        deployment.setContextPath(getContextPath());
+        deployment.setDeploymentName("spring-boot");
+        if (isRegisterDefaultServlet()) {
+            deployment.addServlet(Servlets.servlet("default", DefaultServlet.class));
+        }
+        configureErrorPages(deployment);
+        deployment.setServletStackTraces(ServletStackTraces.NONE);
+        deployment.setResourceManager(getDocumentRootResourceManager());
+        configureMimeMappings(deployment);
+        for (UndertowDeploymentInfoCustomizer customizer : this.deploymentInfoCustomizers) {
+            customizer.customize(deployment);
+        }
+        DeploymentManager manager = Servlets.defaultContainer().addDeployment(deployment);
+        manager.deploy();
+        SessionManager sessionManager = manager.getDeployment().getSessionManager();
+        int sessionTimeout = (getSessionTimeout() > 0 ? getSessionTimeout() : -1);
+        sessionManager.setDefaultSessionTimeout(sessionTimeout);
+        return manager;
+    }
 
-	public void setIoThreads(Integer ioThreads) {
-		this.ioThreads = ioThreads;
-	}
+    private void registerServletContainerInitializerToDriveServletContextInitializers(
+            DeploymentInfo deployment, ServletContextInitializer... initializers) {
+        ServletContextInitializer[] mergedInitializers = mergeInitializers(initializers);
+        Initializer initializer = new Initializer(mergedInitializers);
+        deployment.addServletContainerInitalizer(new ServletContainerInitializerInfo(
+                Initializer.class,
+                new ImmediateInstanceFactory<ServletContainerInitializer>(initializer),
+                NO_CLASSES));
+    }
 
-	public void setWorkerThreads(Integer workerThreads) {
-		this.workerThreads = workerThreads;
-	}
+    private ClassLoader getServletClassLoader() {
+        if (this.resourceLoader != null) {
+            return this.resourceLoader.getClassLoader();
+        }
+        return getClass().getClassLoader();
+    }
 
-	public void setDirectBuffers(Boolean directBuffers) {
-		this.directBuffers = directBuffers;
-	}
+    private ResourceManager getDocumentRootResourceManager() {
+        File root = getValidDocumentRoot();
+        if (root != null && root.isDirectory()) {
+            return new FileResourceManager(root, 0);
+        }
+        if (root != null && root.isFile()) {
+            return new JarResourcemanager(root);
+        }
+        if (this.resourceLoader != null) {
+            return new ClassPathResourceManager(this.resourceLoader.getClassLoader(), "");
+        }
+        return new ClassPathResourceManager(getClass().getClassLoader(), "");
+    }
 
-	/**
-	 * Undertow {@link ResourceManager} for JAR resources.
-	 */
-	private static class JarResourcemanager implements ResourceManager {
+    private void configureErrorPages(DeploymentInfo servletBuilder) {
+        for (ErrorPage errorPage : getErrorPages()) {
+            servletBuilder.addErrorPage(getUndertowErrorPage(errorPage));
+        }
+    }
 
-		private final String jarPath;
+    private io.undertow.servlet.api.ErrorPage getUndertowErrorPage(ErrorPage errorPage) {
+        if (errorPage.getStatus() != null) {
+            return new io.undertow.servlet.api.ErrorPage(errorPage.getPath(),
+                    errorPage.getStatusCode());
+        }
+        if (errorPage.getException() != null) {
+            return new io.undertow.servlet.api.ErrorPage(errorPage.getPath(),
+                    errorPage.getException());
+        }
+        return new io.undertow.servlet.api.ErrorPage(errorPage.getPath());
+    }
 
-		public JarResourcemanager(File jarFile) {
-			this(jarFile.getAbsolutePath());
-		}
+    private void configureMimeMappings(DeploymentInfo servletBuilder) {
+        for (Mapping mimeMapping : getMimeMappings()) {
+            servletBuilder.addMimeMapping(new MimeMapping(mimeMapping.getExtension(),
+                    mimeMapping.getMimeType()));
+        }
+    }
 
-		public JarResourcemanager(String jarPath) {
-			this.jarPath = jarPath;
-		}
+    /**
+     * Factory method called to create the {@link UndertowEmbeddedServletContainer}.
+     * Subclasses can override this method to return a different
+     * {@link UndertowEmbeddedServletContainer} or apply additional processing to the
+     * {@link Builder} and {@link DeploymentManager} used to bootstrap Undertow
+     *
+     * @param builder the builder
+     * @param manager the deployment manager
+     * @param port    the port that Undertow should listen on
+     * @return a new {@link UndertowEmbeddedServletContainer} instance
+     */
+    protected UndertowEmbeddedServletContainer getUndertowEmbeddedServletContainer(
+            Builder builder, DeploymentManager manager, int port) {
+        return new UndertowEmbeddedServletContainer(builder, manager, getContextPath(),
+                port, port >= 0);
+    }
 
-		@Override
-		public Resource getResource(String path) throws IOException {
-			URL url = new URL("jar:file:" + this.jarPath + "!" + path);
-			URLResource resource = new URLResource(url, url.openConnection(), path);
-			if (resource.getContentLength() < 0) {
-				return null;
-			}
-			return resource;
-		}
+    @Override
+    public void setResourceLoader(ResourceLoader resourceLoader) {
+        this.resourceLoader = resourceLoader;
+    }
 
-		@Override
-		public boolean isResourceChangeListenerSupported() {
-			return false;
-		}
+    public void setBufferSize(Integer bufferSize) {
+        this.bufferSize = bufferSize;
+    }
 
-		@Override
-		public void registerResourceChangeListener(ResourceChangeListener listener) {
-			throw UndertowMessages.MESSAGES.resourceChangeListenerNotSupported();
+    public void setBuffersPerRegion(Integer buffersPerRegion) {
+        this.buffersPerRegion = buffersPerRegion;
+    }
 
-		}
+    public void setIoThreads(Integer ioThreads) {
+        this.ioThreads = ioThreads;
+    }
 
-		@Override
-		public void removeResourceChangeListener(ResourceChangeListener listener) {
-			throw UndertowMessages.MESSAGES.resourceChangeListenerNotSupported();
-		}
+    public void setWorkerThreads(Integer workerThreads) {
+        this.workerThreads = workerThreads;
+    }
 
-		@Override
-		public void close() throws IOException {
-		}
+    public void setDirectBuffers(Boolean directBuffers) {
+        this.directBuffers = directBuffers;
+    }
 
-	}
+    /**
+     * Undertow {@link ResourceManager} for JAR resources.
+     */
+    private static class JarResourcemanager implements ResourceManager {
 
-	/**
-	 * {@link ServletContainerInitializer} to initialize {@link ServletContextInitializer
-	 * ServletContextInitializers}.
-	 */
-	private static class Initializer implements ServletContainerInitializer {
+        private final String jarPath;
 
-		private final ServletContextInitializer[] initializers;
+        public JarResourcemanager(File jarFile) {
+            this(jarFile.getAbsolutePath());
+        }
 
-		public Initializer(ServletContextInitializer[] initializers) {
-			this.initializers = initializers;
-		}
+        public JarResourcemanager(String jarPath) {
+            this.jarPath = jarPath;
+        }
 
-		@Override
-		public void onStartup(Set<Class<?>> classes, ServletContext servletContext)
-				throws ServletException {
-			for (ServletContextInitializer initializer : this.initializers) {
-				initializer.onStartup(servletContext);
-			}
-		}
+        @Override
+        public Resource getResource(String path) throws IOException {
+            URL url = new URL("jar:file:" + this.jarPath + "!" + path);
+            URLResource resource = new URLResource(url, url.openConnection(), path);
+            if (resource.getContentLength() < 0) {
+                return null;
+            }
+            return resource;
+        }
 
-	}
+        @Override
+        public boolean isResourceChangeListenerSupported() {
+            return false;
+        }
+
+        @Override
+        public void registerResourceChangeListener(ResourceChangeListener listener) {
+            throw UndertowMessages.MESSAGES.resourceChangeListenerNotSupported();
+
+        }
+
+        @Override
+        public void removeResourceChangeListener(ResourceChangeListener listener) {
+            throw UndertowMessages.MESSAGES.resourceChangeListenerNotSupported();
+        }
+
+        @Override
+        public void close() throws IOException {
+        }
+
+    }
+
+    /**
+     * {@link ServletContainerInitializer} to initialize {@link ServletContextInitializer
+     * ServletContextInitializers}.
+     */
+    private static class Initializer implements ServletContainerInitializer {
+
+        private final ServletContextInitializer[] initializers;
+
+        public Initializer(ServletContextInitializer[] initializers) {
+            this.initializers = initializers;
+        }
+
+        @Override
+        public void onStartup(Set<Class<?>> classes, ServletContext servletContext)
+                throws ServletException {
+            for (ServletContextInitializer initializer : this.initializers) {
+                initializer.onStartup(servletContext);
+            }
+        }
+
+    }
 
 }

--- a/spring-boot/src/main/java/org/springframework/boot/context/embedded/undertow/UndertowEmbeddedServletContainerFactory.java
+++ b/spring-boot/src/main/java/org/springframework/boot/context/embedded/undertow/UndertowEmbeddedServletContainerFactory.java
@@ -65,497 +65,510 @@ import java.util.*;
  * @since 1.2.0
  */
 public class UndertowEmbeddedServletContainerFactory extends
-        AbstractEmbeddedServletContainerFactory implements ResourceLoaderAware {
-
-    private static final Set<Class<?>> NO_CLASSES = Collections.emptySet();
-
-    private List<UndertowBuilderCustomizer> builderCustomizers = new ArrayList<UndertowBuilderCustomizer>();
-
-    private List<UndertowDeploymentInfoCustomizer> deploymentInfoCustomizers = new ArrayList<UndertowDeploymentInfoCustomizer>();
-
-    private ResourceLoader resourceLoader;
-
-    private Integer bufferSize;
-
-    private Integer buffersPerRegion;
-
-    private Integer ioThreads;
-
-    private Integer workerThreads;
-
-    private Boolean directBuffers;
-
-    private File baseDirectory;
-
-    private String accessLogPattern;
-
-    private boolean accessLogEnabled = false;
-
-    /**
-     * Create a new {@link UndertowEmbeddedServletContainerFactory} instance.
-     */
-    public UndertowEmbeddedServletContainerFactory() {
-        super();
-        getJspServlet().setRegistered(false);
-    }
-
-    /**
-     * Create a new {@link UndertowEmbeddedServletContainerFactory} that listens for
-     * requests using the specified port.
-     *
-     * @param port the port to listen on
-     */
-    public UndertowEmbeddedServletContainerFactory(int port) {
-        super(port);
-        getJspServlet().setRegistered(false);
-    }
-
-    /**
-     * Create a new {@link UndertowEmbeddedServletContainerFactory} with the specified
-     * context path and port.
-     *
-     * @param contextPath root the context path
-     * @param port        the port to listen on
-     */
-    public UndertowEmbeddedServletContainerFactory(String contextPath, int port) {
-        super(contextPath, port);
-        getJspServlet().setRegistered(false);
-    }
-
-    /**
-     * Returns a mutable collection of the {@link UndertowBuilderCustomizer}s that will be
-     * applied to the Undertow {@link Builder} .
-     *
-     * @return the customizers that will be applied
-     */
-    public Collection<UndertowBuilderCustomizer> getBuilderCustomizers() {
-        return this.builderCustomizers;
-    }
-
-    /**
-     * Set {@link UndertowBuilderCustomizer}s that should be applied to the Undertow
-     * {@link Builder}. Calling this method will replace any existing customizers.
-     *
-     * @param customizers the customizers to set
-     */
-    public void setBuilderCustomizers(
-            Collection<? extends UndertowBuilderCustomizer> customizers) {
-        Assert.notNull(customizers, "Customizers must not be null");
-        this.builderCustomizers = new ArrayList<UndertowBuilderCustomizer>(customizers);
-    }
-
-    /**
-     * Add {@link UndertowBuilderCustomizer}s that should be used to customize the
-     * Undertow {@link Builder}.
-     *
-     * @param customizers the customizers to add
-     */
-    public void addBuilderCustomizers(UndertowBuilderCustomizer... customizers) {
-        Assert.notNull(customizers, "Customizers must not be null");
-        this.builderCustomizers.addAll(Arrays.asList(customizers));
-    }
-
-    /**
-     * Returns a mutable collection of the {@link UndertowDeploymentInfoCustomizer}s that
-     * will be applied to the Undertow {@link DeploymentInfo} .
-     *
-     * @return the customizers that will be applied
-     */
-    public Collection<UndertowDeploymentInfoCustomizer> getDeploymentInfoCustomizers() {
-        return this.deploymentInfoCustomizers;
-    }
-
-    /**
-     * Set {@link UndertowDeploymentInfoCustomizer}s that should be applied to the
-     * Undertow {@link DeploymentInfo}. Calling this method will replace any existing
-     * customizers.
-     *
-     * @param customizers the customizers to set
-     */
-    public void setDeploymentInfoCustomizers(
-            Collection<? extends UndertowDeploymentInfoCustomizer> customizers) {
-        Assert.notNull(customizers, "Customizers must not be null");
-        this.deploymentInfoCustomizers = new ArrayList<UndertowDeploymentInfoCustomizer>(
-                customizers);
-    }
-
-    /**
-     * Add {@link UndertowDeploymentInfoCustomizer}s that should be used to customize the
-     * Undertow {@link DeploymentInfo}.
-     *
-     * @param customizers the customizers to add
-     */
-    public void addDeploymentInfoCustomizers(
-            UndertowDeploymentInfoCustomizer... customizers) {
-        Assert.notNull(customizers, "UndertowDeploymentInfoCustomizers must not be null");
-        this.deploymentInfoCustomizers.addAll(Arrays.asList(customizers));
-    }
-
-    /**
-     * Set the Undertow base directory. If not specified a temporary directory will be used.
-     *
-     * @param baseDirectory the tomcat base directory
-     */
-    public void setBaseDirectory(File baseDirectory) {
-        this.baseDirectory = baseDirectory;
-    }
-
-    /**
-     * Set the access log pattern.
-     *
-     * @param accessLogPattern The pattern for access log
-     */
-    public void setAccessLogPattern(String accessLogPattern) {
-        this.accessLogPattern = accessLogPattern;
-    }
-
-    /**
-     * Get access log configuration.
-     *
-     * @return Getter for access_log flag.
-     */
-    public boolean isAccessLogEnabled() {
-        return accessLogEnabled;
-    }
-
-    /**
-     * Flag to turn on/off the access_log.
-     *
-     * @param accessLogEnabled The flag value
-     */
-    public void setAccessLogEnabled(boolean accessLogEnabled) {
-
-        this.accessLogEnabled = accessLogEnabled;
-    }
-
-    @Override
-    public EmbeddedServletContainer getEmbeddedServletContainer(
-            ServletContextInitializer... initializers) {
-        DeploymentManager manager = createDeploymentManager(initializers);
-        int port = getPort();
-        Builder builder = createBuilder(port);
-        return new UndertowEmbeddedServletContainer(builder, manager, getContextPath(),
-                port, port >= 0);
-    }
-
-    private Builder createBuilder(int port) {
-        Builder builder = Undertow.builder();
-        if (this.bufferSize != null) {
-            builder.setBufferSize(this.bufferSize);
-        }
-        if (this.buffersPerRegion != null) {
-            builder.setBuffersPerRegion(this.buffersPerRegion);
-        }
-        if (this.ioThreads != null) {
-            builder.setIoThreads(this.ioThreads);
-        }
-        if (this.workerThreads != null) {
-            builder.setWorkerThreads(this.workerThreads);
-        }
-        if (this.directBuffers != null) {
-            builder.setDirectBuffers(this.directBuffers);
-        }
-        if (getSsl() != null && getSsl().isEnabled()) {
-            configureSsl(getSsl(), port, builder);
-        } else {
-            builder.addHttpListener(port, getListenAddress());
-        }
-        for (UndertowBuilderCustomizer customizer : this.builderCustomizers) {
-            customizer.customize(builder);
-        }
-
-        return builder;
-    }
-
-    private void configureSsl(Ssl ssl, int port, Builder builder) {
-        try {
-            SSLContext sslContext = SSLContext.getInstance(ssl.getProtocol());
-            sslContext.init(getKeyManagers(), getTrustManagers(), null);
-            builder.addHttpsListener(port, getListenAddress(), sslContext);
-            builder.setSocketOption(Options.SSL_CLIENT_AUTH_MODE,
-                    getSslClientAuthMode(ssl));
-        } catch (NoSuchAlgorithmException ex) {
-            throw new IllegalStateException(ex);
-        } catch (KeyManagementException ex) {
-            throw new IllegalStateException(ex);
-        }
-    }
-
-    // configure access_log
-    private void configureAccessLog(DeploymentInfo deploymentInfo) {
-        deploymentInfo.addInitialHandlerChainWrapper(new HandlerWrapper() {
-            @Override
-            public HttpHandler wrap(HttpHandler handler) {
-                try {
-                    Xnio xnio = Xnio.getInstance(Undertow.class.getClassLoader());
-                    XnioWorker worker = xnio.createWorker(OptionMap.builder().getMap());
-                    File baseDir = (baseDirectory != null ? baseDirectory : createTempDir("undertow"));
-                    String formatString = (accessLogPattern != null) ? accessLogPattern : "common";
-                    DefaultAccessLogReceiver accessLogReceiver = new DefaultAccessLogReceiver(worker, baseDir, "access_log");
-                    return new AccessLogHandler(handler, accessLogReceiver, formatString, Undertow.class.getClassLoader());
-                } catch (IOException ex) {
-                    throw new IllegalStateException(ex);
-                }
-            }
-        });
-    }
-
-    private String getListenAddress() {
-        if (getAddress() == null) {
-            return "0.0.0.0";
-        }
-        return getAddress().getHostAddress();
-    }
-
-    private SslClientAuthMode getSslClientAuthMode(Ssl ssl) {
-        if (ssl.getClientAuth() == ClientAuth.NEED) {
-            return SslClientAuthMode.REQUIRED;
-        }
-        if (ssl.getClientAuth() == ClientAuth.WANT) {
-            return SslClientAuthMode.REQUESTED;
-        }
-        return SslClientAuthMode.NOT_REQUESTED;
-    }
-
-    private KeyManager[] getKeyManagers() {
-        try {
-            Ssl ssl = getSsl();
-            String keyStoreType = ssl.getKeyStoreType();
-            if (keyStoreType == null) {
-                keyStoreType = "JKS";
-            }
-            KeyStore keyStore = KeyStore.getInstance(keyStoreType);
-            URL url = ResourceUtils.getURL(ssl.getKeyStore());
-            keyStore.load(url.openStream(), ssl.getKeyStorePassword().toCharArray());
-
-            // Get key manager to provide client credentials.
-            KeyManagerFactory keyManagerFactory = KeyManagerFactory
-                    .getInstance(KeyManagerFactory.getDefaultAlgorithm());
-            char[] keyPassword = ssl.getKeyPassword() != null ? ssl.getKeyPassword()
-                    .toCharArray() : ssl.getKeyStorePassword().toCharArray();
-            keyManagerFactory.init(keyStore, keyPassword);
-            return keyManagerFactory.getKeyManagers();
-        } catch (Exception ex) {
-            throw new IllegalStateException(ex);
-        }
-    }
-
-    private TrustManager[] getTrustManagers() {
-        try {
-            Ssl ssl = getSsl();
-            String trustStoreType = ssl.getTrustStoreType();
-            if (trustStoreType == null) {
-                trustStoreType = "JKS";
-            }
-            String trustStore = ssl.getTrustStore();
-            if (trustStore == null) {
-                return null;
-            }
-            KeyStore trustedKeyStore = KeyStore.getInstance(trustStoreType);
-            URL url = ResourceUtils.getURL(trustStore);
-            trustedKeyStore.load(url.openStream(), ssl.getTrustStorePassword()
-                    .toCharArray());
-            TrustManagerFactory trustManagerFactory = TrustManagerFactory
-                    .getInstance(TrustManagerFactory.getDefaultAlgorithm());
-            trustManagerFactory.init(trustedKeyStore);
-            return trustManagerFactory.getTrustManagers();
-        } catch (Exception ex) {
-            throw new IllegalStateException(ex);
-        }
-    }
-
-    private DeploymentManager createDeploymentManager(
-            ServletContextInitializer... initializers) {
-        DeploymentInfo deployment = Servlets.deployment();
-        registerServletContainerInitializerToDriveServletContextInitializers(deployment,
-                initializers);
-        deployment.setClassLoader(getServletClassLoader());
-        deployment.setContextPath(getContextPath());
-        deployment.setDeploymentName("spring-boot");
-        if (isRegisterDefaultServlet()) {
-            deployment.addServlet(Servlets.servlet("default", DefaultServlet.class));
-        }
-        configureErrorPages(deployment);
-        deployment.setServletStackTraces(ServletStackTraces.NONE);
-        deployment.setResourceManager(getDocumentRootResourceManager());
-        configureMimeMappings(deployment);
-        for (UndertowDeploymentInfoCustomizer customizer : this.deploymentInfoCustomizers) {
-            customizer.customize(deployment);
-        }
-        if (isAccessLogEnabled()) { configureAccessLog(deployment); }
-        DeploymentManager manager = Servlets.defaultContainer().addDeployment(deployment);
-        manager.deploy();
-        SessionManager sessionManager = manager.getDeployment().getSessionManager();
-        int sessionTimeout = (getSessionTimeout() > 0 ? getSessionTimeout() : -1);
-        sessionManager.setDefaultSessionTimeout(sessionTimeout);
-        return manager;
-    }
-
-    private void registerServletContainerInitializerToDriveServletContextInitializers(
-            DeploymentInfo deployment, ServletContextInitializer... initializers) {
-        ServletContextInitializer[] mergedInitializers = mergeInitializers(initializers);
-        Initializer initializer = new Initializer(mergedInitializers);
-        deployment.addServletContainerInitalizer(new ServletContainerInitializerInfo(
-                Initializer.class,
-                new ImmediateInstanceFactory<ServletContainerInitializer>(initializer),
-                NO_CLASSES));
-    }
-
-    private ClassLoader getServletClassLoader() {
-        if (this.resourceLoader != null) {
-            return this.resourceLoader.getClassLoader();
-        }
-        return getClass().getClassLoader();
-    }
-
-    private ResourceManager getDocumentRootResourceManager() {
-        File root = getValidDocumentRoot();
-        if (root != null && root.isDirectory()) {
-            return new FileResourceManager(root, 0);
-        }
-        if (root != null && root.isFile()) {
-            return new JarResourcemanager(root);
-        }
-        if (this.resourceLoader != null) {
-            return new ClassPathResourceManager(this.resourceLoader.getClassLoader(), "");
-        }
-        return new ClassPathResourceManager(getClass().getClassLoader(), "");
-    }
-
-    private void configureErrorPages(DeploymentInfo servletBuilder) {
-        for (ErrorPage errorPage : getErrorPages()) {
-            servletBuilder.addErrorPage(getUndertowErrorPage(errorPage));
-        }
-    }
-
-    private io.undertow.servlet.api.ErrorPage getUndertowErrorPage(ErrorPage errorPage) {
-        if (errorPage.getStatus() != null) {
-            return new io.undertow.servlet.api.ErrorPage(errorPage.getPath(),
-                    errorPage.getStatusCode());
-        }
-        if (errorPage.getException() != null) {
-            return new io.undertow.servlet.api.ErrorPage(errorPage.getPath(),
-                    errorPage.getException());
-        }
-        return new io.undertow.servlet.api.ErrorPage(errorPage.getPath());
-    }
-
-    private void configureMimeMappings(DeploymentInfo servletBuilder) {
-        for (Mapping mimeMapping : getMimeMappings()) {
-            servletBuilder.addMimeMapping(new MimeMapping(mimeMapping.getExtension(),
-                    mimeMapping.getMimeType()));
-        }
-    }
-
-    /**
-     * Factory method called to create the {@link UndertowEmbeddedServletContainer}.
-     * Subclasses can override this method to return a different
-     * {@link UndertowEmbeddedServletContainer} or apply additional processing to the
-     * {@link Builder} and {@link DeploymentManager} used to bootstrap Undertow
-     *
-     * @param builder the builder
-     * @param manager the deployment manager
-     * @param port    the port that Undertow should listen on
-     * @return a new {@link UndertowEmbeddedServletContainer} instance
-     */
-    protected UndertowEmbeddedServletContainer getUndertowEmbeddedServletContainer(
-            Builder builder, DeploymentManager manager, int port) {
-        return new UndertowEmbeddedServletContainer(builder, manager, getContextPath(),
-                port, port >= 0);
-    }
-
-    @Override
-    public void setResourceLoader(ResourceLoader resourceLoader) {
-        this.resourceLoader = resourceLoader;
-    }
-
-    public void setBufferSize(Integer bufferSize) {
-        this.bufferSize = bufferSize;
-    }
-
-    public void setBuffersPerRegion(Integer buffersPerRegion) {
-        this.buffersPerRegion = buffersPerRegion;
-    }
-
-    public void setIoThreads(Integer ioThreads) {
-        this.ioThreads = ioThreads;
-    }
-
-    public void setWorkerThreads(Integer workerThreads) {
-        this.workerThreads = workerThreads;
-    }
-
-    public void setDirectBuffers(Boolean directBuffers) {
-        this.directBuffers = directBuffers;
-    }
-
-    /**
-     * Undertow {@link ResourceManager} for JAR resources.
-     */
-    private static class JarResourcemanager implements ResourceManager {
-
-        private final String jarPath;
-
-        public JarResourcemanager(File jarFile) {
-            this(jarFile.getAbsolutePath());
-        }
-
-        public JarResourcemanager(String jarPath) {
-            this.jarPath = jarPath;
-        }
-
-        @Override
-        public Resource getResource(String path) throws IOException {
-            URL url = new URL("jar:file:" + this.jarPath + "!" + path);
-            URLResource resource = new URLResource(url, url.openConnection(), path);
-            if (resource.getContentLength() < 0) {
-                return null;
-            }
-            return resource;
-        }
-
-        @Override
-        public boolean isResourceChangeListenerSupported() {
-            return false;
-        }
-
-        @Override
-        public void registerResourceChangeListener(ResourceChangeListener listener) {
-            throw UndertowMessages.MESSAGES.resourceChangeListenerNotSupported();
-
-        }
-
-        @Override
-        public void removeResourceChangeListener(ResourceChangeListener listener) {
-            throw UndertowMessages.MESSAGES.resourceChangeListenerNotSupported();
-        }
-
-        @Override
-        public void close() throws IOException {
-        }
-
-    }
-
-    /**
-     * {@link ServletContainerInitializer} to initialize {@link ServletContextInitializer
-     * ServletContextInitializers}.
-     */
-    private static class Initializer implements ServletContainerInitializer {
-
-        private final ServletContextInitializer[] initializers;
-
-        public Initializer(ServletContextInitializer[] initializers) {
-            this.initializers = initializers;
-        }
-
-        @Override
-        public void onStartup(Set<Class<?>> classes, ServletContext servletContext)
-                throws ServletException {
-            for (ServletContextInitializer initializer : this.initializers) {
-                initializer.onStartup(servletContext);
-            }
-        }
-
-    }
+		AbstractEmbeddedServletContainerFactory implements ResourceLoaderAware {
+
+	private static final Set<Class<?>> NO_CLASSES = Collections.emptySet();
+
+	private List<UndertowBuilderCustomizer> builderCustomizers = new ArrayList<UndertowBuilderCustomizer>();
+
+	private List<UndertowDeploymentInfoCustomizer> deploymentInfoCustomizers = new ArrayList<UndertowDeploymentInfoCustomizer>();
+
+	private ResourceLoader resourceLoader;
+
+	private Integer bufferSize;
+
+	private Integer buffersPerRegion;
+
+	private Integer ioThreads;
+
+	private Integer workerThreads;
+
+	private Boolean directBuffers;
+
+	private File baseDirectory;
+
+	private String accessLogPattern;
+
+	private boolean accessLogEnabled = false;
+
+	/**
+	 * Create a new {@link UndertowEmbeddedServletContainerFactory} instance.
+	 */
+	public UndertowEmbeddedServletContainerFactory() {
+		super();
+		getJspServlet().setRegistered(false);
+	}
+
+	/**
+	 * Create a new {@link UndertowEmbeddedServletContainerFactory} that listens for
+	 * requests using the specified port.
+	 *
+	 * @param port the port to listen on
+	 */
+	public UndertowEmbeddedServletContainerFactory(int port) {
+		super(port);
+		getJspServlet().setRegistered(false);
+	}
+
+	/**
+	 * Create a new {@link UndertowEmbeddedServletContainerFactory} with the specified
+	 * context path and port.
+	 *
+	 * @param contextPath root the context path
+	 * @param port the port to listen on
+	 */
+	public UndertowEmbeddedServletContainerFactory(String contextPath, int port) {
+		super(contextPath, port);
+		getJspServlet().setRegistered(false);
+	}
+
+	/**
+	 * Returns a mutable collection of the {@link UndertowBuilderCustomizer}s that will be
+	 * applied to the Undertow {@link Builder} .
+	 *
+	 * @return the customizers that will be applied
+	 */
+	public Collection<UndertowBuilderCustomizer> getBuilderCustomizers() {
+		return this.builderCustomizers;
+	}
+
+	/**
+	 * Set {@link UndertowBuilderCustomizer}s that should be applied to the Undertow
+	 * {@link Builder}. Calling this method will replace any existing customizers.
+	 *
+	 * @param customizers the customizers to set
+	 */
+	public void setBuilderCustomizers(
+			Collection<? extends UndertowBuilderCustomizer> customizers) {
+		Assert.notNull(customizers, "Customizers must not be null");
+		this.builderCustomizers = new ArrayList<UndertowBuilderCustomizer>(customizers);
+	}
+
+	/**
+	 * Add {@link UndertowBuilderCustomizer}s that should be used to customize the
+	 * Undertow {@link Builder}.
+	 *
+	 * @param customizers the customizers to add
+	 */
+	public void addBuilderCustomizers(UndertowBuilderCustomizer... customizers) {
+		Assert.notNull(customizers, "Customizers must not be null");
+		this.builderCustomizers.addAll(Arrays.asList(customizers));
+	}
+
+	/**
+	 * Returns a mutable collection of the {@link UndertowDeploymentInfoCustomizer}s that
+	 * will be applied to the Undertow {@link DeploymentInfo} .
+	 *
+	 * @return the customizers that will be applied
+	 */
+	public Collection<UndertowDeploymentInfoCustomizer> getDeploymentInfoCustomizers() {
+		return this.deploymentInfoCustomizers;
+	}
+
+	/**
+	 * Set {@link UndertowDeploymentInfoCustomizer}s that should be applied to the
+	 * Undertow {@link DeploymentInfo}. Calling this method will replace any existing
+	 * customizers.
+	 *
+	 * @param customizers the customizers to set
+	 */
+	public void setDeploymentInfoCustomizers(
+			Collection<? extends UndertowDeploymentInfoCustomizer> customizers) {
+		Assert.notNull(customizers, "Customizers must not be null");
+		this.deploymentInfoCustomizers = new ArrayList<UndertowDeploymentInfoCustomizer>(
+				customizers);
+	}
+
+	/**
+	 * Add {@link UndertowDeploymentInfoCustomizer}s that should be used to customize the
+	 * Undertow {@link DeploymentInfo}.
+	 *
+	 * @param customizers the customizers to add
+	 */
+	public void addDeploymentInfoCustomizers(
+			UndertowDeploymentInfoCustomizer... customizers) {
+		Assert.notNull(customizers, "UndertowDeploymentInfoCustomizers must not be null");
+		this.deploymentInfoCustomizers.addAll(Arrays.asList(customizers));
+	}
+
+	/**
+	 * Set the Undertow base directory. If not specified a temporary directory will be
+	 * used.
+	 *
+	 * @param baseDirectory the tomcat base directory
+	 */
+	public void setBaseDirectory(File baseDirectory) {
+		this.baseDirectory = baseDirectory;
+	}
+
+	/**
+	 * Set the access log pattern.
+	 *
+	 * @param accessLogPattern The pattern for access log
+	 */
+	public void setAccessLogPattern(String accessLogPattern) {
+		this.accessLogPattern = accessLogPattern;
+	}
+
+	/**
+	 * Get access log configuration.
+	 *
+	 * @return Getter for access_log flag.
+	 */
+	public boolean isAccessLogEnabled() {
+		return accessLogEnabled;
+	}
+
+	/**
+	 * Flag to turn on/off the access_log.
+	 *
+	 * @param accessLogEnabled The flag value
+	 */
+	public void setAccessLogEnabled(boolean accessLogEnabled) {
+
+		this.accessLogEnabled = accessLogEnabled;
+	}
+
+	@Override
+	public EmbeddedServletContainer getEmbeddedServletContainer(
+			ServletContextInitializer... initializers) {
+		DeploymentManager manager = createDeploymentManager(initializers);
+		int port = getPort();
+		Builder builder = createBuilder(port);
+		return new UndertowEmbeddedServletContainer(builder, manager, getContextPath(),
+				port, port >= 0);
+	}
+
+	private Builder createBuilder(int port) {
+		Builder builder = Undertow.builder();
+		if (this.bufferSize != null) {
+			builder.setBufferSize(this.bufferSize);
+		}
+		if (this.buffersPerRegion != null) {
+			builder.setBuffersPerRegion(this.buffersPerRegion);
+		}
+		if (this.ioThreads != null) {
+			builder.setIoThreads(this.ioThreads);
+		}
+		if (this.workerThreads != null) {
+			builder.setWorkerThreads(this.workerThreads);
+		}
+		if (this.directBuffers != null) {
+			builder.setDirectBuffers(this.directBuffers);
+		}
+		if (getSsl() != null && getSsl().isEnabled()) {
+			configureSsl(getSsl(), port, builder);
+		}
+		else {
+			builder.addHttpListener(port, getListenAddress());
+		}
+		for (UndertowBuilderCustomizer customizer : this.builderCustomizers) {
+			customizer.customize(builder);
+		}
+
+		return builder;
+	}
+
+	private void configureSsl(Ssl ssl, int port, Builder builder) {
+		try {
+			SSLContext sslContext = SSLContext.getInstance(ssl.getProtocol());
+			sslContext.init(getKeyManagers(), getTrustManagers(), null);
+			builder.addHttpsListener(port, getListenAddress(), sslContext);
+			builder.setSocketOption(Options.SSL_CLIENT_AUTH_MODE,
+					getSslClientAuthMode(ssl));
+		}
+		catch (NoSuchAlgorithmException ex) {
+			throw new IllegalStateException(ex);
+		}
+		catch (KeyManagementException ex) {
+			throw new IllegalStateException(ex);
+		}
+	}
+
+	// configure access_log
+	private void configureAccessLog(DeploymentInfo deploymentInfo) {
+		deploymentInfo.addInitialHandlerChainWrapper(new HandlerWrapper() {
+			@Override
+			public HttpHandler wrap(HttpHandler handler) {
+				try {
+					Xnio xnio = Xnio.getInstance(Undertow.class.getClassLoader());
+					XnioWorker worker = xnio.createWorker(OptionMap.builder().getMap());
+					File baseDir = (baseDirectory != null ? baseDirectory
+							: createTempDir("undertow"));
+					String formatString = (accessLogPattern != null) ? accessLogPattern
+							: "common";
+					DefaultAccessLogReceiver accessLogReceiver = new DefaultAccessLogReceiver(
+							worker, baseDir, "access_log");
+					return new AccessLogHandler(handler, accessLogReceiver, formatString,
+							Undertow.class.getClassLoader());
+				}
+				catch (IOException ex) {
+					throw new IllegalStateException(ex);
+				}
+			}
+		});
+	}
+
+	private String getListenAddress() {
+		if (getAddress() == null) {
+			return "0.0.0.0";
+		}
+		return getAddress().getHostAddress();
+	}
+
+	private SslClientAuthMode getSslClientAuthMode(Ssl ssl) {
+		if (ssl.getClientAuth() == ClientAuth.NEED) {
+			return SslClientAuthMode.REQUIRED;
+		}
+		if (ssl.getClientAuth() == ClientAuth.WANT) {
+			return SslClientAuthMode.REQUESTED;
+		}
+		return SslClientAuthMode.NOT_REQUESTED;
+	}
+
+	private KeyManager[] getKeyManagers() {
+		try {
+			Ssl ssl = getSsl();
+			String keyStoreType = ssl.getKeyStoreType();
+			if (keyStoreType == null) {
+				keyStoreType = "JKS";
+			}
+			KeyStore keyStore = KeyStore.getInstance(keyStoreType);
+			URL url = ResourceUtils.getURL(ssl.getKeyStore());
+			keyStore.load(url.openStream(), ssl.getKeyStorePassword().toCharArray());
+
+			// Get key manager to provide client credentials.
+			KeyManagerFactory keyManagerFactory = KeyManagerFactory
+					.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+			char[] keyPassword = ssl.getKeyPassword() != null ? ssl.getKeyPassword()
+					.toCharArray() : ssl.getKeyStorePassword().toCharArray();
+			keyManagerFactory.init(keyStore, keyPassword);
+			return keyManagerFactory.getKeyManagers();
+		}
+		catch (Exception ex) {
+			throw new IllegalStateException(ex);
+		}
+	}
+
+	private TrustManager[] getTrustManagers() {
+		try {
+			Ssl ssl = getSsl();
+			String trustStoreType = ssl.getTrustStoreType();
+			if (trustStoreType == null) {
+				trustStoreType = "JKS";
+			}
+			String trustStore = ssl.getTrustStore();
+			if (trustStore == null) {
+				return null;
+			}
+			KeyStore trustedKeyStore = KeyStore.getInstance(trustStoreType);
+			URL url = ResourceUtils.getURL(trustStore);
+			trustedKeyStore.load(url.openStream(), ssl.getTrustStorePassword()
+					.toCharArray());
+			TrustManagerFactory trustManagerFactory = TrustManagerFactory
+					.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+			trustManagerFactory.init(trustedKeyStore);
+			return trustManagerFactory.getTrustManagers();
+		}
+		catch (Exception ex) {
+			throw new IllegalStateException(ex);
+		}
+	}
+
+	private DeploymentManager createDeploymentManager(
+			ServletContextInitializer... initializers) {
+		DeploymentInfo deployment = Servlets.deployment();
+		registerServletContainerInitializerToDriveServletContextInitializers(deployment,
+				initializers);
+		deployment.setClassLoader(getServletClassLoader());
+		deployment.setContextPath(getContextPath());
+		deployment.setDeploymentName("spring-boot");
+		if (isRegisterDefaultServlet()) {
+			deployment.addServlet(Servlets.servlet("default", DefaultServlet.class));
+		}
+		configureErrorPages(deployment);
+		deployment.setServletStackTraces(ServletStackTraces.NONE);
+		deployment.setResourceManager(getDocumentRootResourceManager());
+		configureMimeMappings(deployment);
+		for (UndertowDeploymentInfoCustomizer customizer : this.deploymentInfoCustomizers) {
+			customizer.customize(deployment);
+		}
+		if (isAccessLogEnabled()) {
+			configureAccessLog(deployment);
+		}
+		DeploymentManager manager = Servlets.defaultContainer().addDeployment(deployment);
+		manager.deploy();
+		SessionManager sessionManager = manager.getDeployment().getSessionManager();
+		int sessionTimeout = (getSessionTimeout() > 0 ? getSessionTimeout() : -1);
+		sessionManager.setDefaultSessionTimeout(sessionTimeout);
+		return manager;
+	}
+
+	private void registerServletContainerInitializerToDriveServletContextInitializers(
+			DeploymentInfo deployment, ServletContextInitializer... initializers) {
+		ServletContextInitializer[] mergedInitializers = mergeInitializers(initializers);
+		Initializer initializer = new Initializer(mergedInitializers);
+		deployment.addServletContainerInitalizer(new ServletContainerInitializerInfo(
+				Initializer.class,
+				new ImmediateInstanceFactory<ServletContainerInitializer>(initializer),
+				NO_CLASSES));
+	}
+
+	private ClassLoader getServletClassLoader() {
+		if (this.resourceLoader != null) {
+			return this.resourceLoader.getClassLoader();
+		}
+		return getClass().getClassLoader();
+	}
+
+	private ResourceManager getDocumentRootResourceManager() {
+		File root = getValidDocumentRoot();
+		if (root != null && root.isDirectory()) {
+			return new FileResourceManager(root, 0);
+		}
+		if (root != null && root.isFile()) {
+			return new JarResourcemanager(root);
+		}
+		if (this.resourceLoader != null) {
+			return new ClassPathResourceManager(this.resourceLoader.getClassLoader(), "");
+		}
+		return new ClassPathResourceManager(getClass().getClassLoader(), "");
+	}
+
+	private void configureErrorPages(DeploymentInfo servletBuilder) {
+		for (ErrorPage errorPage : getErrorPages()) {
+			servletBuilder.addErrorPage(getUndertowErrorPage(errorPage));
+		}
+	}
+
+	private io.undertow.servlet.api.ErrorPage getUndertowErrorPage(ErrorPage errorPage) {
+		if (errorPage.getStatus() != null) {
+			return new io.undertow.servlet.api.ErrorPage(errorPage.getPath(),
+					errorPage.getStatusCode());
+		}
+		if (errorPage.getException() != null) {
+			return new io.undertow.servlet.api.ErrorPage(errorPage.getPath(),
+					errorPage.getException());
+		}
+		return new io.undertow.servlet.api.ErrorPage(errorPage.getPath());
+	}
+
+	private void configureMimeMappings(DeploymentInfo servletBuilder) {
+		for (Mapping mimeMapping : getMimeMappings()) {
+			servletBuilder.addMimeMapping(new MimeMapping(mimeMapping.getExtension(),
+					mimeMapping.getMimeType()));
+		}
+	}
+
+	/**
+	 * Factory method called to create the {@link UndertowEmbeddedServletContainer}.
+	 * Subclasses can override this method to return a different
+	 * {@link UndertowEmbeddedServletContainer} or apply additional processing to the
+	 * {@link Builder} and {@link DeploymentManager} used to bootstrap Undertow
+	 *
+	 * @param builder the builder
+	 * @param manager the deployment manager
+	 * @param port the port that Undertow should listen on
+	 * @return a new {@link UndertowEmbeddedServletContainer} instance
+	 */
+	protected UndertowEmbeddedServletContainer getUndertowEmbeddedServletContainer(
+			Builder builder, DeploymentManager manager, int port) {
+		return new UndertowEmbeddedServletContainer(builder, manager, getContextPath(),
+				port, port >= 0);
+	}
+
+	@Override
+	public void setResourceLoader(ResourceLoader resourceLoader) {
+		this.resourceLoader = resourceLoader;
+	}
+
+	public void setBufferSize(Integer bufferSize) {
+		this.bufferSize = bufferSize;
+	}
+
+	public void setBuffersPerRegion(Integer buffersPerRegion) {
+		this.buffersPerRegion = buffersPerRegion;
+	}
+
+	public void setIoThreads(Integer ioThreads) {
+		this.ioThreads = ioThreads;
+	}
+
+	public void setWorkerThreads(Integer workerThreads) {
+		this.workerThreads = workerThreads;
+	}
+
+	public void setDirectBuffers(Boolean directBuffers) {
+		this.directBuffers = directBuffers;
+	}
+
+	/**
+	 * Undertow {@link ResourceManager} for JAR resources.
+	 */
+	private static class JarResourcemanager implements ResourceManager {
+
+		private final String jarPath;
+
+		public JarResourcemanager(File jarFile) {
+			this(jarFile.getAbsolutePath());
+		}
+
+		public JarResourcemanager(String jarPath) {
+			this.jarPath = jarPath;
+		}
+
+		@Override
+		public Resource getResource(String path) throws IOException {
+			URL url = new URL("jar:file:" + this.jarPath + "!" + path);
+			URLResource resource = new URLResource(url, url.openConnection(), path);
+			if (resource.getContentLength() < 0) {
+				return null;
+			}
+			return resource;
+		}
+
+		@Override
+		public boolean isResourceChangeListenerSupported() {
+			return false;
+		}
+
+		@Override
+		public void registerResourceChangeListener(ResourceChangeListener listener) {
+			throw UndertowMessages.MESSAGES.resourceChangeListenerNotSupported();
+
+		}
+
+		@Override
+		public void removeResourceChangeListener(ResourceChangeListener listener) {
+			throw UndertowMessages.MESSAGES.resourceChangeListenerNotSupported();
+		}
+
+		@Override
+		public void close() throws IOException {
+		}
+
+	}
+
+	/**
+	 * {@link ServletContainerInitializer} to initialize {@link ServletContextInitializer
+	 * ServletContextInitializers}.
+	 */
+	private static class Initializer implements ServletContainerInitializer {
+
+		private final ServletContextInitializer[] initializers;
+
+		public Initializer(ServletContextInitializer[] initializers) {
+			this.initializers = initializers;
+		}
+
+		@Override
+		public void onStartup(Set<Class<?>> classes, ServletContext servletContext)
+				throws ServletException {
+			for (ServletContextInitializer initializer : this.initializers) {
+				initializer.onStartup(servletContext);
+			}
+		}
+
+	}
 
 }


### PR DESCRIPTION
Providing access_log configuration for Undertow at application.yml(properties) like the configuration available for Tomcat.
```
server.undertow.access-log-enabled: true
server.undertow.access-log-pattern: common #default
server.undertow.basedir:  #default /tmp
```